### PR TITLE
IRacingPlugin  sends events before LuaScripts are ready

### DIFF
--- a/Backend/Plugins/FileMonitorPlugin.cs
+++ b/Backend/Plugins/FileMonitorPlugin.cs
@@ -53,6 +53,8 @@ namespace Slipstream.Backend.Plugins
                     });
                 }
             }
+
+            EventBus.PublishEvent(new FileMonitorScanCompleted());
         }
 
         private void OnFileMonitorSettings(FileMonitorSettings ev)

--- a/Backend/Plugins/IRacingPlugin.cs
+++ b/Backend/Plugins/IRacingPlugin.cs
@@ -15,6 +15,7 @@ namespace Slipstream.Backend.Plugins
     {
         private readonly iRacingConnection Connection = new iRacingConnection();
         private readonly Shared.IEventBus EventBus;
+        private bool InitializedSeen;
 
         private class CarState
         {
@@ -57,13 +58,12 @@ namespace Slipstream.Backend.Plugins
         private IRacingSessionState? LastSessionState;
         private IRacingRaceFlags? LastRaceFlags;
         private IRacingWeatherInfo? LastWeatherInfo;
-        private bool DelayedStartPeriodExpired = false; // to allow Lua scripts to be up and running, we will wait a bit before sending out events
-        private readonly DateTime StartedAt = DateTime.Now;
         private bool Connected;
 
         public IRacingPlugin(string id, IEventBus eventBus) : base(id, "IRacingPlugin", "IRacingPlugin", "IRacingPlugin")
         {
             EventBus = eventBus;
+            EventHandler.OnInternalInitialized += (s, e) => InitializedSeen = true;
         }
 
 
@@ -74,21 +74,9 @@ namespace Slipstream.Backend.Plugins
 
         public override void Loop()
         {
-            if (!Enabled)
+            if (!Enabled || !InitializedSeen)
             {
                 return;
-            }
-
-            if(!DelayedStartPeriodExpired)
-            {
-                if(StartedAt.AddSeconds(15) > DateTime.Now)
-                {
-                    DelayedStartPeriodExpired = true;
-                }
-                else
-                {
-                    return;
-                }
             }
 
             try

--- a/Backend/Plugins/LuaPlugin.cs
+++ b/Backend/Plugins/LuaPlugin.cs
@@ -21,7 +21,7 @@ namespace Slipstream.Backend.Plugins
         private LuaApi? Api;
         private Lua? Lua;
 
-        public LuaPlugin(string id, IEventBus eventBus, IStateService stateService, LuaSettings settings) : base(id, "LuaPLugin", "LuaPlugin", "Lua")
+        public LuaPlugin(string id, IEventBus eventBus, IStateService stateService, LuaSettings settings) : base(id, "LuaPlugin", "LuaPlugin", "Lua")
         {
             EventBus = eventBus;
             StateService = stateService;

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Improvements**
  - Lua: Add event_to_json() function, that will convert a Slipstream event to a json string. Change debug.lua to use that, making it trivial.
+ - Lua: At start: Make sure all Lua script before IRacingPlugin publishes events
 
 ## [0.2.0](https://github.com/dennis/slipstream/releases/tag/v0.2.0) (2020-12-30)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.1.0...v0.2.0)

--- a/Shared/EventHandler.cs
+++ b/Shared/EventHandler.cs
@@ -50,9 +50,14 @@ namespace Slipstream.Shared
         public delegate void OnInternalFileMonitorFileRenamedHandler(EventHandler source, EventHandlerArgs<Shared.Events.Internal.FileMonitorFileRenamed> e);
         public event OnInternalFileMonitorFileRenamedHandler? OnInternalFileMonitorFileRenamed;
 
+        public delegate void OnInternalFileMonitorScanCompletedHandler(EventHandler source, EventHandlerArgs<Shared.Events.Internal.FileMonitorScanCompleted> e);
+        public event OnInternalFileMonitorScanCompletedHandler? OnInternalFileMonitorScanCompleted;
+
         public delegate void OnInternalCommandPluginStatesHandler(EventHandler source, EventHandlerArgs<Shared.Events.Internal.CommandPluginStates> e);
         public event OnInternalCommandPluginStatesHandler? OnInternalCommandPluginStates;
 
+        public delegate void OnInternalInitializedHandler(EventHandler source, EventHandlerArgs<Shared.Events.Internal.Initialized> e);
+        public event OnInternalInitializedHandler? OnInternalInitialized;
         #endregion
 
         #region Events: Utility
@@ -202,11 +207,24 @@ namespace Slipstream.Shared
                     else
                         OnInternalFileMonitorFileRenamed.Invoke(this, new EventHandlerArgs<Shared.Events.Internal.FileMonitorFileRenamed>(tev));
                     break;
+                case Shared.Events.Internal.FileMonitorScanCompleted tev:
+                    if (OnInternalFileMonitorScanCompleted == null)
+                        OnDefault?.Invoke(this, new EventHandlerArgs<IEvent>(tev));
+                    else
+                        OnInternalFileMonitorScanCompleted.Invoke(this, new EventHandlerArgs<Shared.Events.Internal.FileMonitorScanCompleted>(tev));
+                    break;
                 case Shared.Events.Internal.CommandPluginStates tev:
                     if (OnInternalCommandPluginStates == null)
                         OnDefault?.Invoke(this, new EventHandlerArgs<IEvent>(tev));
                     else
                         OnInternalCommandPluginStates.Invoke(this, new EventHandlerArgs<Shared.Events.Internal.CommandPluginStates>(tev));
+                    break;
+
+                case Shared.Events.Internal.Initialized tev:
+                    if (OnInternalInitialized == null)
+                        OnDefault?.Invoke(this, new EventHandlerArgs<IEvent>(tev));
+                    else
+                        OnInternalInitialized.Invoke(this, new EventHandlerArgs<Shared.Events.Internal.Initialized>(tev));
                     break;
 
                 // Utility

--- a/Shared/Events/Internal/FileMonitorScanCompleted.cs
+++ b/Shared/Events/Internal/FileMonitorScanCompleted.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+
+namespace Slipstream.Shared.Events.Internal
+{
+    public class FileMonitorScanCompleted : IEvent
+    {
+        public string EventType => "FileMonitorScanCompleted";
+        public bool ExcludeFromTxrx => true;
+    }
+}

--- a/Shared/Events/Internal/Initialized.cs
+++ b/Shared/Events/Internal/Initialized.cs
@@ -1,0 +1,10 @@
+﻿#nullable enable
+
+namespace Slipstream.Shared.Events.Internal
+{
+    public class Initialized : IEvent
+    {
+        public string EventType => "Initialized";
+        public bool ExcludeFromTxrx => true;
+    }
+}

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -149,6 +149,8 @@
     <Compile Include="Frontend\SettingsForm.Designer.cs">
       <DependentUpon>SettingsForm.cs</DependentUpon>
     </Compile>
+    <Compile Include="Shared\Events\Internal\FileMonitorScanCompleted.cs" />
+    <Compile Include="Shared\Events\Internal\Initialized.cs" />
     <Compile Include="Shared\Events\Internal\CommandPluginStates.cs" />
     <Compile Include="Shared\Events\Setting\TxrxSettings.cs" />
     <Compile Include="Shared\IApplicationConfiguration.cs" />


### PR DESCRIPTION
Plugins are registered and enabled all at once. But since Lua scripts are loaded by `FileTriggerPlugin`, they will first be loaded after we start. And since `IRacingPlugin` starts at the beginning, LuaScripts will miss events concerning Car Info, Weather Info, Track Info etc that `IRacingPlugin` initially published. 

To get around this, this PR adds a `Initialize` and `FileMonitorScanCompleted` event.s `Initialized` will be published once all Lua Script are registered, so `IRacingPlugin` should therefor just wait for this event, before publishing events.

- `FileMonitorPlugin`  (FMP) will emit `FileMonitorScanCompleted` once its done publishing `FileMonitorFileCreated` for existing files, found at startup
- `FileTriggerPlugin` (FTP) listens for events from FMP As long as no `FileMonitorScanCompleted` is seen, it will note down all the Lua scripts that is registered from here. 
- Once `FileMonitorScanCompleted` is seen, it stops noting down lua scripts,and will wait for all Lua scripst to be started (Plugin state "registered"). Once there are zero pending lua scripts, it will emit `Initialized`
- `IRacnigPlugin` awaits for `Initialized` before publishing anything. This also means, that `IRacingPlugin` needs to be registered and enabled when `Initialized` arrives.