### PR TITLE
Store upto 10.000 events that we can replay if needed

### DIFF
--- a/Backend/EventBus.cs
+++ b/Backend/EventBus.cs
@@ -7,8 +7,12 @@ namespace Slipstream.Backend
     public class EventBus : IEventBus
     {
         private readonly IList<EventBusSubscription> Listeners = new List<EventBusSubscription>();
+        private readonly IList<IEvent> Events = new List<IEvent>(EVENT_MAX_SIZE);
         private readonly List<IEvent> PendingEvents = new List<IEvent>();
+        private const int EVENT_MAX_SIZE = 10000;
+        private const int EVENT_DELETE_SIZE = 1000; // when we hit EVENT_MAX_SIZE. How many elements should we remove?
         private volatile bool enabled = false;
+
         public bool Enabled
         {
             get { return enabled; }
@@ -21,6 +25,17 @@ namespace Slipstream.Backend
         }
         public void PublishEvent(IEvent e)
         {
+            lock (Events)
+            {
+                if(Events.Count >= EVENT_MAX_SIZE)
+                {
+                    // Is there a better way for deleting x elements from the beginning?
+                    for (int i = 0; i < EVENT_DELETE_SIZE; i++)
+                        Events.RemoveAt(0);
+                }
+                Events.Add(e);
+            }
+
             lock (Listeners)
             {
                 if (enabled)
@@ -37,12 +52,20 @@ namespace Slipstream.Backend
             }
         }
 
-        public IEventBusSubscription RegisterListener()
+        public IEventBusSubscription RegisterListener(bool fromStart = false)
         {
             var subscription = new EventBusSubscription(this);
 
             lock (Listeners)
             {
+                if (fromStart)
+                {
+                    foreach(var e in Events)
+                    {
+                        subscription.Add(e);
+                    }
+                }
+
                 Listeners.Add(subscription);
             }
 
@@ -57,7 +80,6 @@ namespace Slipstream.Backend
                     _ = Listeners.Remove(a);
             }
         }
-
 
         private void EnableAndFlushPendingEvents()
         {

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 
 **Improvements**
  - Lua: Add event_to_json() function, that will convert a Slipstream event to a json string. Change debug.lua to use that, making it trivial.
+ - UI: Will show all events, even if they are published before UI was ready
 
 ## [0.2.0](https://github.com/dennis/slipstream/releases/tag/v0.2.0) (2020-12-30)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.1.0...v0.2.0)

--- a/Frontend/MainWindow.cs
+++ b/Frontend/MainWindow.cs
@@ -45,7 +45,7 @@ namespace Slipstream.Frontend
 
         private void MainWindow_Load(object sender, EventArgs e)
         {
-            EventBusSubscription = EventBus.RegisterListener();
+            EventBusSubscription = EventBus.RegisterListener(fromBeginning: true);
             EventHandlerThread = new Thread(new ThreadStart(this.EventListenerMain));
             EventHandlerThread.Start();
         }

--- a/Shared/IEventBus.cs
+++ b/Shared/IEventBus.cs
@@ -3,7 +3,7 @@
     public interface IEventBus : IEventProducer
     {
         public bool Enabled { get; set; }
-        IEventBusSubscription RegisterListener();
+        IEventBusSubscription RegisterListener(bool fromBeginning = false);
         void UnregisterSubscription(IEventBusSubscription eventBusSubscription);
     }
 }


### PR DESCRIPTION
UI needs it, as it might be started slightly later than the
plugins. So to show all events in the window, we'll do a
"replay" of all known events.

If 10.000 events is reached, we'll remove 1000 events at
a time.