### PR TITLE
Lazy evaluation eventbus at startup

### DIFF
--- a/Backend/CapturingEventBus.cs
+++ b/Backend/CapturingEventBus.cs
@@ -1,0 +1,73 @@
+﻿using Slipstream.Shared;
+using System.Collections.Generic;
+
+namespace Slipstream.Backend
+{
+    public class CapturingEventBus : IEventBus
+    {
+        private readonly IEventBus RealEventBus; // EventBus that actually sends events
+        private readonly IEventBus CaptorEventBus; // EventBus that captures events instead of sending them
+        private readonly List<IEvent> CapturedEventsList = new List<IEvent>();
+        private IEventBus ActiveEventBus; // What we use currently
+
+        class Captor : IEventBus
+        {
+            private readonly IEventBus EventBus;
+            private readonly List<IEvent> CapturedEvents;
+
+            public Captor(IEventBus eventBus, List<IEvent> capturingEventBus)
+            {
+                EventBus = eventBus;
+                CapturedEvents = capturingEventBus;
+            }
+
+            public bool Enabled { get => EventBus.Enabled; set { EventBus.Enabled = value; } }
+
+            public void PublishEvent(IEvent e)
+            {
+                CapturedEvents.Add(e);
+            }
+
+            public IEventBusSubscription RegisterListener(bool fromBeginning = false)
+            {
+                return EventBus.RegisterListener(fromBeginning);
+            }
+
+            public void UnregisterSubscription(IEventBusSubscription eventBusSubscription)
+            {
+                EventBus.UnregisterSubscription(eventBusSubscription);
+            }
+        }
+
+        public bool Enabled { get => ActiveEventBus.Enabled; set { ActiveEventBus.Enabled = value; } }
+        public IEvent[] CapturedEvents { get { return CapturedEventsList.ToArray(); } }
+
+        public CapturingEventBus(IEventBus eventBus)
+        {
+            RealEventBus   = eventBus;
+            CaptorEventBus = new Captor(eventBus, CapturedEventsList);
+            ActiveEventBus = CaptorEventBus;
+        }
+
+        public void PublishEvent(IEvent e)
+        {
+            ActiveEventBus.PublishEvent(e);
+        }
+
+        public IEventBusSubscription RegisterListener(bool fromBeginning = false)
+        {
+            return ActiveEventBus.RegisterListener(fromBeginning);
+        }
+
+        public void UnregisterSubscription(IEventBusSubscription eventBusSubscription)
+        {
+            ActiveEventBus.UnregisterSubscription(eventBusSubscription);
+        }
+
+        public void StopCapturing()
+        {
+            CapturedEventsList.Clear();
+            ActiveEventBus = RealEventBus;
+        }
+    }
+}

--- a/Backend/Engine.cs
+++ b/Backend/Engine.cs
@@ -100,16 +100,9 @@ enable_plugin(""FileMonitorPlugin"")
 
         private void OnInternalBootupEvents(InternalBootupEvents @event)
         {
-            foreach(var e in @event.Events.Split('\n'))
+            foreach(var e in EventSerdeService.DeserializeMultiple(@event.Events))
             {
-                if(e.Length > 0)
-                {
-                    var f = EventSerdeService.Deserialize(e);
-                    if(f != null)
-                    {
-                        CapturedBootupEvents.Add(f);
-                    }
-                }
+                CapturedBootupEvents.Add(e);
             }
 
             // Postponing deadline

--- a/Backend/Engine.cs
+++ b/Backend/Engine.cs
@@ -2,7 +2,9 @@
 using Slipstream.Shared;
 using Slipstream.Shared.Events.Internal;
 using System;
+using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using static Slipstream.Shared.IEventFactory;
 
 #nullable enable
@@ -16,14 +18,19 @@ namespace Slipstream.Backend
         private readonly IPluginManager PluginManager;
         private readonly IEventBusSubscription Subscription;
         private readonly IPluginFactory PluginFactory;
+        private readonly IEventSerdeService EventSerdeService;
         private readonly Shared.EventHandler EventHandler = new Shared.EventHandler();
 
-        public Engine(IEventFactory eventFactory, IEventBus eventBus, IPluginFactory pluginFactory, IPluginManager pluginManager, ILuaSevice luaService, IApplicationVersionService applicationVersionService) : base("engine")
+        private DateTime? BootupEventsDeadline;
+        private readonly List<IEvent> CapturedBootupEvents = new List<IEvent>();
+
+        public Engine(IEventFactory eventFactory, IEventBus eventBus, IPluginFactory pluginFactory, IPluginManager pluginManager, ILuaSevice luaService, IApplicationVersionService applicationVersionService, IEventSerdeService eventSerdeService) : base("engine")
         {
             EventFactory = eventFactory;
             EventBus = eventBus;
             PluginFactory = pluginFactory;
             PluginManager = pluginManager;
+            EventSerdeService = eventSerdeService;
 
             Subscription = EventBus.RegisterListener();
 
@@ -33,6 +40,9 @@ namespace Slipstream.Backend
             EventHandler.OnInternalCommandPluginDisable += (s, e) => PluginManager.FindPluginAndExecute(e.Event.Id, (plugin) => PluginManager.DisablePlugin(plugin));
             EventHandler.OnInternalCommandPluginStates += (s, e) => OnCommandPluginStates(e.Event);
             EventHandler.OnInternalReconfigured += (s, e) => OnInternalReconfigured();
+            EventHandler.OnInternalBootupEvents += (s, e) => OnInternalBootupEvents(e.Event);
+
+            BootupEventsDeadline = DateTime.Now.AddMilliseconds(500);
 
             // Plugins..
             {
@@ -88,6 +98,24 @@ enable_plugin(""FileMonitorPlugin"")
             EventBus.Enabled = true;
         }
 
+        private void OnInternalBootupEvents(InternalBootupEvents @event)
+        {
+            foreach(var e in @event.Events.Split('\n'))
+            {
+                if(e.Length > 0)
+                {
+                    var f = EventSerdeService.Deserialize(e);
+                    if(f != null)
+                    {
+                        CapturedBootupEvents.Add(f);
+                    }
+                }
+            }
+
+            // Postponing deadline
+            BootupEventsDeadline = DateTime.Now.AddMilliseconds(500);
+        }
+
         private void OnInternalReconfigured()
         {
             PluginManager.RestartReconfigurablePlugins();
@@ -120,6 +148,20 @@ enable_plugin(""FileMonitorPlugin"")
         {
             while (!Stopped)
             {
+                if(BootupEventsDeadline != null && BootupEventsDeadline <= DateTime.Now)
+                {
+                    // We have collected the events published when LuaScripts were booting. To avoid
+                    // publishing the same events multiple times, we remove duplicates and then publish it
+                    foreach (var e in CapturedBootupEvents.Distinct())
+                    {
+                        EventBus.PublishEvent(e);
+                    }
+
+                    CapturedBootupEvents.Clear();
+
+                    BootupEventsDeadline = null;
+                }
+ 
                 EventHandler.HandleEvent(Subscription.NextEvent(10));
             }
         }

--- a/Backend/EventBus.cs
+++ b/Backend/EventBus.cs
@@ -60,9 +60,12 @@ namespace Slipstream.Backend
             {
                 if (fromStart)
                 {
-                    foreach(var e in Events)
+                    lock(Events)
                     {
-                        subscription.Add(e);
+                        foreach (var e in Events)
+                        {
+                            subscription.Add(e);
+                        }
                     }
                 }
 

--- a/Backend/IEvent.cs
+++ b/Backend/IEvent.cs
@@ -1,0 +1,6 @@
+﻿namespace Slipstream.Backend
+{
+    internal interface IEvent<T>
+    {
+    }
+}

--- a/Backend/IPluginFactory.cs
+++ b/Backend/IPluginFactory.cs
@@ -1,10 +1,14 @@
 ﻿#nullable enable
 
+using Slipstream.Shared;
+
 namespace Slipstream.Backend
 {
     public interface IPluginFactory
     {
         IPlugin CreatePlugin(string id, string name);
+        IPlugin CreatePlugin(string id, string name, IEventBus eventBus);
         IPlugin CreatePlugin<T>(string pluginId, string name, T configuration);
+        IPlugin CreatePlugin<T>(string pluginId, string name, IEventBus eventBus, T configuration);
     }
 }

--- a/Backend/PluginManager.cs
+++ b/Backend/PluginManager.cs
@@ -187,20 +187,30 @@ namespace Slipstream.Backend
 
         public IPlugin CreatePlugin(string id, string name)
         {
+            return CreatePlugin(id, name, EventBus);
+        }
+
+        public IPlugin CreatePlugin(string id, string name, IEventBus eventBus)
+        {
             return name switch
             {
-                "FileMonitorPlugin" => new FileMonitorPlugin(id, EventFactory, EventBus, ApplicationConfiguration),
-                "FileTriggerPlugin" => new FileTriggerPlugin(id, EventFactory, EventBus, this, this),
-                "AudioPlugin" => new AudioPlugin(id, EventFactory, EventBus, ApplicationConfiguration),
-                "IRacingPlugin" => new IRacingPlugin(id, EventFactory, EventBus),
-                "TwitchPlugin" => new TwitchPlugin(id, EventFactory, EventBus, ApplicationConfiguration),
-                "TransmitterPlugin" => new TransmitterPlugin(id, EventFactory, EventBus, TxrxService, ApplicationConfiguration),
-                "ReceiverPlugin" => new ReceiverPlugin(id, EventFactory, EventBus, TxrxService, ApplicationConfiguration),
+                "FileMonitorPlugin" => new FileMonitorPlugin(id, EventFactory, eventBus, ApplicationConfiguration),
+                "FileTriggerPlugin" => new FileTriggerPlugin(id, EventFactory, eventBus, this, this),
+                "AudioPlugin" => new AudioPlugin(id, EventFactory, eventBus, ApplicationConfiguration),
+                "IRacingPlugin" => new IRacingPlugin(id, EventFactory, eventBus),
+                "TwitchPlugin" => new TwitchPlugin(id, EventFactory, eventBus, ApplicationConfiguration),
+                "TransmitterPlugin" => new TransmitterPlugin(id, EventFactory, eventBus, TxrxService, ApplicationConfiguration),
+                "ReceiverPlugin" => new ReceiverPlugin(id, EventFactory, eventBus, TxrxService, ApplicationConfiguration),
                 _ => throw new Exception($"Unknown plugin '{name}'"),
             };
         }
 
         public IPlugin CreatePlugin<T>(string pluginId, string name, T configuration)
+        {
+            return CreatePlugin(pluginId, name, EventBus, configuration);
+        }
+
+        public IPlugin CreatePlugin<T>(string pluginId, string name, IEventBus eventBus, T configuration)
         {
             return name switch
             {

--- a/Backend/Services/EventSerdeService.cs
+++ b/Backend/Services/EventSerdeService.cs
@@ -29,6 +29,8 @@ namespace Slipstream.Backend.Services
 
             Debug.Assert(eventType != null);
 
+            json = json.Replace(@"\n", "\n");
+
             var obj = JsonSerializer.Deserialize(json, EventsMap[eventType!]);
 
             if (obj != null)
@@ -41,9 +43,42 @@ namespace Slipstream.Backend.Services
             }
         }
 
+        public IEvent[] DeserializeMultiple(string json)
+        {
+            var result = new List<IEvent>();
+
+            foreach(var line in json.Split('\n'))
+            {
+                if(line.Length > 0)
+                {
+                    var @event = Deserialize(line);
+
+                    if(@event != null)
+                    {
+                        result.Add(@event);
+                    }
+                }
+            }
+
+            return result.ToArray();
+        }
+
         public string Serialize(IEvent @event)
         {
-            return JsonSerializer.Serialize(@event, EventsMap[@event.EventType], null);
+            var json = JsonSerializer.Serialize(@event, EventsMap[@event.EventType], null);
+
+            return json.Replace("\n", @"\n") + "\n";
+        }
+
+        public string SerializeMultiple(IEvent[] events)
+        {
+            string result = "";
+            foreach(var @event in events)
+            {
+                result += Serialize(@event);
+            }
+
+            return result;
         }
     }
 }

--- a/Backend/Services/IEventSerdeService.cs
+++ b/Backend/Services/IEventSerdeService.cs
@@ -8,5 +8,7 @@ namespace Slipstream.Backend.Services
     {
         IEvent? Deserialize(string json);
         string Serialize(IEvent @event);
+        IEvent[] DeserializeMultiple(string json);
+        string SerializeMultiple(IEvent[] events);
     }
 }

--- a/Backend/Services/LuaService.cs
+++ b/Backend/Services/LuaService.cs
@@ -20,8 +20,7 @@ namespace Slipstream.Backend.Services
 
         public ILuaContext Parse(string filename, string logPrefix)
         {
-            var ctx = new LuaContext(EventFactory, EventBus, StateService, filename, logPrefix);
-            return ctx;
+            return new LuaContext(EventFactory, EventBus, StateService, filename, logPrefix);
         }
     }
 }

--- a/Backend/Worker.cs
+++ b/Backend/Worker.cs
@@ -24,7 +24,10 @@ namespace Slipstream.Backend
         protected Worker(string name)
         {
             Name = name;
-            WorkerThread = new Thread(new ThreadStart(this.Main));
+            WorkerThread = new Thread(new ThreadStart(this.Main))
+            {
+                Name = name
+            };
         }
 
         public void Start()

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 ## Next version
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.3.0...main)
+ - Lua: Deduplicate identical events. If one or more scripts sends the same
+   event on the eventbus during start, they will be deduplicated. This means,
+   that we avoid having the same response to the same command repeated several
+   times. Fx. Having multiple scripts that asks for IRacing WeatherInfo upon
+   start, will be deduplicated as only one response is needed for these scripts.
 
 ## [0.3.0](https://github.com/dennis/slipstream/releases/tag/v0.3.0) (2020-01-05)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.2.0...v0.3.0)

--- a/Shared/EventFactory.cs
+++ b/Shared/EventFactory.cs
@@ -1,4 +1,5 @@
-﻿using Slipstream.Shared.Events.Audio;
+﻿using Slipstream.Backend.Services;
+using Slipstream.Shared.Events.Audio;
 using Slipstream.Shared.Events.FileMonitor;
 using Slipstream.Shared.Events.Internal;
 using Slipstream.Shared.Events.IRacing;
@@ -13,6 +14,12 @@ namespace Slipstream.Shared
 {
     public class EventFactory : IEventFactory
     {
+        private readonly IEventSerdeService EventSerdeService;
+        public EventFactory(IEventSerdeService eventSerdeService)
+        {
+            EventSerdeService = eventSerdeService;
+        }
+
         public AudioCommandPlay CreateAudioCommandPlay(string filename, float? volume)
         {
             return new AudioCommandPlay { Filename = filename, Volume = volume };
@@ -81,6 +88,21 @@ namespace Slipstream.Shared
         public InternalReconfigured CreateInternalReconfigured()
         {
             return new InternalReconfigured();
+        }
+
+        public InternalBootupEvents CreateInternalBootupEvents(IEvent[] events)
+        {
+            string json = "";
+
+            foreach(var e in events)
+            {
+                json += EventSerdeService.Serialize(e) + "\n";
+            }
+
+            return new InternalBootupEvents
+            {
+                Events = json
+            };
         }
 
         public IRacingCarCompletedLap CreateIRacingCarCompletedLap(double sessionTime, long carIdx, double time, int lapsCompleted, float? fuelDiff, bool localUser)

--- a/Shared/EventHandler.cs
+++ b/Shared/EventHandler.cs
@@ -46,7 +46,10 @@ namespace Slipstream.Shared
 
         public delegate void OnInternalReconfiguredHandler(EventHandler source, EventHandlerArgs<Shared.Events.Internal.InternalReconfigured> e);
         public event OnInternalReconfiguredHandler? OnInternalReconfigured;
-        
+
+        public delegate void OnInternalBootupEventsHandler(EventHandler source, EventHandlerArgs<Shared.Events.Internal.InternalBootupEvents> e);
+        public event OnInternalBootupEventsHandler? OnInternalBootupEvents;
+
         #endregion
 
         #region FileMonitor
@@ -204,6 +207,13 @@ namespace Slipstream.Shared
                         OnDefault?.Invoke(this, new EventHandlerArgs<IEvent>(tev));
                     else
                         OnInternalReconfigured.Invoke(this, new EventHandlerArgs<Shared.Events.Internal.InternalReconfigured>(tev));
+                    break;
+
+                case Shared.Events.Internal.InternalBootupEvents tev:
+                    if (OnInternalBootupEvents == null)
+                        OnDefault?.Invoke(this, new EventHandlerArgs<IEvent>(tev));
+                    else
+                        OnInternalBootupEvents.Invoke(this, new EventHandlerArgs<Shared.Events.Internal.InternalBootupEvents>(tev));
                     break;
 
                 // File Monitor

--- a/Shared/Events/Audio/AudioCommandPlay.cs
+++ b/Shared/Events/Audio/AudioCommandPlay.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Audio
 {
     public class AudioCommandPlay : IEvent
@@ -8,5 +10,24 @@ namespace Slipstream.Shared.Events.Audio
         public bool ExcludeFromTxrx => true;
         public string? Filename { get; set; }
         public float? Volume { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is AudioCommandPlay play &&
+                   EventType == play.EventType &&
+                   ExcludeFromTxrx == play.ExcludeFromTxrx &&
+                   Filename == play.Filename &&
+                   Volume == play.Volume;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 2126878269;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Filename);
+            hashCode = hashCode * -1521134295 + Volume.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Audio/AudioCommandSay.cs
+++ b/Shared/Events/Audio/AudioCommandSay.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Audio
 {
     public class AudioCommandSay : IEvent
@@ -8,5 +10,24 @@ namespace Slipstream.Shared.Events.Audio
         public bool ExcludeFromTxrx => true;
         public string? Message { get; set; }
         public float? Volume { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is AudioCommandSay say &&
+                   EventType == say.EventType &&
+                   ExcludeFromTxrx == say.ExcludeFromTxrx &&
+                   Message == say.Message &&
+                   Volume == say.Volume;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1098881401;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message);
+            hashCode = hashCode * -1521134295 + Volume.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/FileMonitor/FileMonitorFileChanged.cs
+++ b/Shared/Events/FileMonitor/FileMonitorFileChanged.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.FileMonitor
 {
     public class FileMonitorFileChanged : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.FileMonitor
         public string EventType => "FileMonitorFileChanged";
         public bool ExcludeFromTxrx => true;
         public string? FilePath { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FileMonitorFileChanged changed &&
+                   EventType == changed.EventType &&
+                   ExcludeFromTxrx == changed.ExcludeFromTxrx &&
+                   FilePath == changed.FilePath;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1499696410;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(FilePath);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/FileMonitor/FileMonitorFileCreated.cs
+++ b/Shared/Events/FileMonitor/FileMonitorFileCreated.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.FileMonitor
 {
     public class FileMonitorFileCreated : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.FileMonitor
         public string EventType => "FileMonitorFileCreated";
         public bool ExcludeFromTxrx => true;
         public string? FilePath { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FileMonitorFileCreated created &&
+                   EventType == created.EventType &&
+                   ExcludeFromTxrx == created.ExcludeFromTxrx &&
+                   FilePath == created.FilePath;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1499696410;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(FilePath);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/FileMonitor/FileMonitorFileDeleted.cs
+++ b/Shared/Events/FileMonitor/FileMonitorFileDeleted.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.FileMonitor
 {
     public class FileMonitorFileDeleted : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.FileMonitor
         public string EventType => "FileMonitorFileDeleted";
         public bool ExcludeFromTxrx => true;
         public string? FilePath { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FileMonitorFileDeleted deleted &&
+                   EventType == deleted.EventType &&
+                   ExcludeFromTxrx == deleted.ExcludeFromTxrx &&
+                   FilePath == deleted.FilePath;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1499696410;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(FilePath);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/FileMonitor/FileMonitorFileRenamed.cs
+++ b/Shared/Events/FileMonitor/FileMonitorFileRenamed.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.FileMonitor
 {
     public class FileMonitorFileRenamed : IEvent
@@ -8,5 +10,24 @@ namespace Slipstream.Shared.Events.FileMonitor
         public bool ExcludeFromTxrx => true;
         public string? FilePath { get; set; }
         public string? OldFilePath { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FileMonitorFileRenamed renamed &&
+                   EventType == renamed.EventType &&
+                   ExcludeFromTxrx == renamed.ExcludeFromTxrx &&
+                   FilePath == renamed.FilePath &&
+                   OldFilePath == renamed.OldFilePath;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1615632865;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(FilePath);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(OldFilePath);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/FileMonitor/FileMonitorScanCompleted.cs
+++ b/Shared/Events/FileMonitor/FileMonitorScanCompleted.cs
@@ -1,10 +1,27 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.FileMonitor
 {
     public class FileMonitorScanCompleted : IEvent
     {
         public string EventType => "FileMonitorScanCompleted";
         public bool ExcludeFromTxrx => true;
+
+        public override bool Equals(object? obj)
+        {
+            return obj is FileMonitorScanCompleted completed &&
+                   EventType == completed.EventType &&
+                   ExcludeFromTxrx == completed.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingCarCompletedLap.cs
+++ b/Shared/Events/IRacing/IRacingCarCompletedLap.cs
@@ -1,4 +1,6 @@
-﻿namespace Slipstream.Shared.Events.IRacing
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingCarCompletedLap : IEvent
     {
@@ -10,5 +12,32 @@
         public int LapsCompleted { get; set; }
         public float? FuelDiff { get; set; }
         public bool LocalUser { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IRacingCarCompletedLap lap &&
+                   EventType == lap.EventType &&
+                   ExcludeFromTxrx == lap.ExcludeFromTxrx &&
+                   SessionTime == lap.SessionTime &&
+                   CarIdx == lap.CarIdx &&
+                   Time == lap.Time &&
+                   LapsCompleted == lap.LapsCompleted &&
+                   FuelDiff == lap.FuelDiff &&
+                   LocalUser == lap.LocalUser;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 508366613;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + CarIdx.GetHashCode();
+            hashCode = hashCode * -1521134295 + Time.GetHashCode();
+            hashCode = hashCode * -1521134295 + LapsCompleted.GetHashCode();
+            hashCode = hashCode * -1521134295 + FuelDiff.GetHashCode();
+            hashCode = hashCode * -1521134295 + LocalUser.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingCarInfo.cs
+++ b/Shared/Events/IRacing/IRacingCarInfo.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingCarInfo : IEvent
@@ -18,6 +20,45 @@ namespace Slipstream.Shared.Events.IRacing
         public long CurrentDriverIRating { get; set; }
         public bool LocalUser { get; set; }
         public long Spectator { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingCarInfo info &&
+                   EventType == info.EventType &&
+                   ExcludeFromTxrx == info.ExcludeFromTxrx &&
+                   SessionTime == info.SessionTime &&
+                   CarIdx == info.CarIdx &&
+                   CarNumber == info.CarNumber &&
+                   CurrentDriverUserID == info.CurrentDriverUserID &&
+                   CurrentDriverName == info.CurrentDriverName &&
+                   TeamID == info.TeamID &&
+                   TeamName == info.TeamName &&
+                   CarName == info.CarName &&
+                   CarNameShort == info.CarNameShort &&
+                   CurrentDriverIRating == info.CurrentDriverIRating &&
+                   LocalUser == info.LocalUser &&
+                   Spectator == info.Spectator;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 854757270;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + CarIdx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CarNumber);
+            hashCode = hashCode * -1521134295 + CurrentDriverUserID.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CurrentDriverName);
+            hashCode = hashCode * -1521134295 + TeamID.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TeamName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CarName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(CarNameShort);
+            hashCode = hashCode * -1521134295 + CurrentDriverIRating.GetHashCode();
+            hashCode = hashCode * -1521134295 + LocalUser.GetHashCode();
+            hashCode = hashCode * -1521134295 + Spectator.GetHashCode();
+            return hashCode;
+        }
 
         public bool SameAs(IRacingCarInfo other)
         {

--- a/Shared/Events/IRacing/IRacingConnected.cs
+++ b/Shared/Events/IRacing/IRacingConnected.cs
@@ -1,8 +1,25 @@
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingConnected : IEvent
     {
         public string EventType => "IRacingConnected";
         public bool ExcludeFromTxrx => false;
+
+        public override bool Equals(object obj)
+        {
+            return obj is IRacingConnected connected &&
+                   EventType == connected.EventType &&
+                   ExcludeFromTxrx == connected.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingCurrentSession.cs
+++ b/Shared/Events/IRacing/IRacingCurrentSession.cs
@@ -1,8 +1,9 @@
 using System;
+using System.Collections.Generic;
 
 namespace Slipstream.Shared.Events.IRacing
 {
-    public class IRacingCurrentSession : IEvent, IEquatable<IRacingCurrentSession>
+    public class IRacingCurrentSession : IEvent
     {
         public string EventType => "IRacingCurrentSession";
         public bool ExcludeFromTxrx => false;
@@ -12,13 +13,29 @@ namespace Slipstream.Shared.Events.IRacing
         public int TotalSessionLaps { get; set; }
         public double TotalSessionTime { get; set; }
 
-        public bool Equals(IRacingCurrentSession other)
+        public override bool Equals(object obj)
         {
-            return SessionType == other.SessionType &&
-                TimeLimited == other.TimeLimited &&
-                LapsLimited == other.LapsLimited &&
-                TotalSessionLaps == other.TotalSessionLaps &&
-                TotalSessionTime == other.TotalSessionTime;
+            return obj is IRacingCurrentSession session &&
+                   EventType == session.EventType &&
+                   ExcludeFromTxrx == session.ExcludeFromTxrx &&
+                   SessionType == session.SessionType &&
+                   TimeLimited == session.TimeLimited &&
+                   LapsLimited == session.LapsLimited &&
+                   TotalSessionLaps == session.TotalSessionLaps &&
+                   TotalSessionTime == session.TotalSessionTime;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 2106272073;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SessionType);
+            hashCode = hashCode * -1521134295 + TimeLimited.GetHashCode();
+            hashCode = hashCode * -1521134295 + LapsLimited.GetHashCode();
+            hashCode = hashCode * -1521134295 + TotalSessionLaps.GetHashCode();
+            hashCode = hashCode * -1521134295 + TotalSessionTime.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/Shared/Events/IRacing/IRacingDisconnected.cs
+++ b/Shared/Events/IRacing/IRacingDisconnected.cs
@@ -1,8 +1,25 @@
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingDisconnected : IEvent
     {
         public string EventType => "IRacingDisconnected";
         public bool ExcludeFromTxrx => false;
+
+        public override bool Equals(object obj)
+        {
+            return obj is IRacingDisconnected disconnected &&
+                   EventType == disconnected.EventType &&
+                   ExcludeFromTxrx == disconnected.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingDriverIncident.cs
+++ b/Shared/Events/IRacing/IRacingDriverIncident.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingDriverIncident : IEvent
@@ -10,5 +12,24 @@ namespace Slipstream.Shared.Events.IRacing
         public int IncidentCount { get; set; }
 
         public int IncidentDelta { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingDriverIncident incident &&
+                   EventType == incident.EventType &&
+                   ExcludeFromTxrx == incident.ExcludeFromTxrx &&
+                   IncidentCount == incident.IncidentCount &&
+                   IncidentDelta == incident.IncidentDelta;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1200671587;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + IncidentCount.GetHashCode();
+            hashCode = hashCode * -1521134295 + IncidentDelta.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingPitEnter.cs
+++ b/Shared/Events/IRacing/IRacingPitEnter.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingPitEnter : IEvent
@@ -7,5 +9,26 @@ namespace Slipstream.Shared.Events.IRacing
         public double SessionTime { get; set; }
         public long CarIdx { get; set; }
         public bool LocalUser { get; set; }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IRacingPitEnter enter &&
+                   EventType == enter.EventType &&
+                   ExcludeFromTxrx == enter.ExcludeFromTxrx &&
+                   SessionTime == enter.SessionTime &&
+                   CarIdx == enter.CarIdx &&
+                   LocalUser == enter.LocalUser;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 2084919435;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + CarIdx.GetHashCode();
+            hashCode = hashCode * -1521134295 + LocalUser.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingPitExit.cs
+++ b/Shared/Events/IRacing/IRacingPitExit.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingPitExit : IEvent
@@ -10,5 +12,28 @@ namespace Slipstream.Shared.Events.IRacing
         public long CarIdx { get; set; }
         public bool LocalUser { get; set; }
         public double? Duration { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingPitExit exit &&
+                   EventType == exit.EventType &&
+                   ExcludeFromTxrx == exit.ExcludeFromTxrx &&
+                   SessionTime == exit.SessionTime &&
+                   CarIdx == exit.CarIdx &&
+                   LocalUser == exit.LocalUser &&
+                   Duration == exit.Duration;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1083203984;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + CarIdx.GetHashCode();
+            hashCode = hashCode * -1521134295 + LocalUser.GetHashCode();
+            hashCode = hashCode * -1521134295 + Duration.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingPitstopReport.cs
+++ b/Shared/Events/IRacing/IRacingPitstopReport.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingPitstopReport : IEvent
@@ -60,5 +62,78 @@ namespace Slipstream.Shared.Events.IRacing
         public long Laps { get; set; }
         public float FuelDiff { get; set; }
         public double Duration { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingPitstopReport report &&
+                   EventType == report.EventType &&
+                   ExcludeFromTxrx == report.ExcludeFromTxrx &&
+                   SessionTime == report.SessionTime &&
+                   CarIdx == report.CarIdx &&
+                   TempLFL == report.TempLFL &&
+                   TempLFM == report.TempLFM &&
+                   TempLFR == report.TempLFR &&
+                   TempRFL == report.TempRFL &&
+                   TempRFM == report.TempRFM &&
+                   TempRFR == report.TempRFR &&
+                   TempLRL == report.TempLRL &&
+                   TempLRM == report.TempLRM &&
+                   TempLRR == report.TempLRR &&
+                   TempRRL == report.TempRRL &&
+                   TempRRM == report.TempRRM &&
+                   TempRRR == report.TempRRR &&
+                   WearLFL == report.WearLFL &&
+                   WearLFM == report.WearLFM &&
+                   WearLFR == report.WearLFR &&
+                   WearRFL == report.WearRFL &&
+                   WearRFM == report.WearRFM &&
+                   WearRFR == report.WearRFR &&
+                   WearLRL == report.WearLRL &&
+                   WearLRM == report.WearLRM &&
+                   WearLRR == report.WearLRR &&
+                   WearRRL == report.WearRRL &&
+                   WearRRM == report.WearRRM &&
+                   WearRRR == report.WearRRR &&
+                   Laps == report.Laps &&
+                   FuelDiff == report.FuelDiff &&
+                   Duration == report.Duration;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1299679726;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + CarIdx.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempLFL.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempLFM.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempLFR.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempRFL.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempRFM.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempRFR.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempLRL.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempLRM.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempLRR.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempRRL.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempRRM.GetHashCode();
+            hashCode = hashCode * -1521134295 + TempRRR.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearLFL.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearLFM.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearLFR.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearRFL.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearRFM.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearRFR.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearLRL.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearLRM.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearLRR.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearRRL.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearRRM.GetHashCode();
+            hashCode = hashCode * -1521134295 + WearRRR.GetHashCode();
+            hashCode = hashCode * -1521134295 + Laps.GetHashCode();
+            hashCode = hashCode * -1521134295 + FuelDiff.GetHashCode();
+            hashCode = hashCode * -1521134295 + Duration.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingRaceFlags.cs
+++ b/Shared/Events/IRacing/IRacingRaceFlags.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingRaceFlags : IEvent
@@ -59,6 +61,73 @@ namespace Slipstream.Shared.Events.IRacing
                White == other.White &&
                Yellow == other.Yellow &&
                YellowWaving == other.YellowWaving;
+        }
+
+        public override bool Equals(object obj)
+        {
+            return obj is IRacingRaceFlags flags &&
+                   EventType == flags.EventType &&
+                   ExcludeFromTxrx == flags.ExcludeFromTxrx &&
+                   SessionTime == flags.SessionTime &&
+                   Black == flags.Black &&
+                   Blue == flags.Blue &&
+                   Caution == flags.Caution &&
+                   CautionWaving == flags.CautionWaving &&
+                   Checkered == flags.Checkered &&
+                   Crossed == flags.Crossed &&
+                   Debris == flags.Debris &&
+                   Disqualify == flags.Disqualify &&
+                   FiveToGo == flags.FiveToGo &&
+                   Furled == flags.Furled &&
+                   Green == flags.Green &&
+                   GreenHeld == flags.GreenHeld &&
+                   OneLapToGreen == flags.OneLapToGreen &&
+                   RandomWaving == flags.RandomWaving &&
+                   Red == flags.Red &&
+                   Repair == flags.Repair &&
+                   Servicible == flags.Servicible &&
+                   StartGo == flags.StartGo &&
+                   StartHidden == flags.StartHidden &&
+                   StartReady == flags.StartReady &&
+                   StartSet == flags.StartSet &&
+                   TenToGo == flags.TenToGo &&
+                   White == flags.White &&
+                   Yellow == flags.Yellow &&
+                   YellowWaving == flags.YellowWaving;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1865722245;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + Black.GetHashCode();
+            hashCode = hashCode * -1521134295 + Blue.GetHashCode();
+            hashCode = hashCode * -1521134295 + Caution.GetHashCode();
+            hashCode = hashCode * -1521134295 + CautionWaving.GetHashCode();
+            hashCode = hashCode * -1521134295 + Checkered.GetHashCode();
+            hashCode = hashCode * -1521134295 + Crossed.GetHashCode();
+            hashCode = hashCode * -1521134295 + Debris.GetHashCode();
+            hashCode = hashCode * -1521134295 + Disqualify.GetHashCode();
+            hashCode = hashCode * -1521134295 + FiveToGo.GetHashCode();
+            hashCode = hashCode * -1521134295 + Furled.GetHashCode();
+            hashCode = hashCode * -1521134295 + Green.GetHashCode();
+            hashCode = hashCode * -1521134295 + GreenHeld.GetHashCode();
+            hashCode = hashCode * -1521134295 + OneLapToGreen.GetHashCode();
+            hashCode = hashCode * -1521134295 + RandomWaving.GetHashCode();
+            hashCode = hashCode * -1521134295 + Red.GetHashCode();
+            hashCode = hashCode * -1521134295 + Repair.GetHashCode();
+            hashCode = hashCode * -1521134295 + Servicible.GetHashCode();
+            hashCode = hashCode * -1521134295 + StartGo.GetHashCode();
+            hashCode = hashCode * -1521134295 + StartHidden.GetHashCode();
+            hashCode = hashCode * -1521134295 + StartReady.GetHashCode();
+            hashCode = hashCode * -1521134295 + StartSet.GetHashCode();
+            hashCode = hashCode * -1521134295 + TenToGo.GetHashCode();
+            hashCode = hashCode * -1521134295 + White.GetHashCode();
+            hashCode = hashCode * -1521134295 + Yellow.GetHashCode();
+            hashCode = hashCode * -1521134295 + YellowWaving.GetHashCode();
+            return hashCode;
         }
     }
 }

--- a/Shared/Events/IRacing/IRacingSessionState.cs
+++ b/Shared/Events/IRacing/IRacingSessionState.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingSessionState : IEvent
@@ -12,6 +14,25 @@ namespace Slipstream.Shared.Events.IRacing
         public bool DifferentTo(IRacingSessionState other)
         {
             return State.Equals(other.State);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingSessionState state &&
+                   EventType == state.EventType &&
+                   ExcludeFromTxrx == state.ExcludeFromTxrx &&
+                   SessionTime == state.SessionTime &&
+                   State == state.State;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1594495278;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(State);
+            return hashCode;
         }
     }
 }

--- a/Shared/Events/IRacing/IRacingTrackInfo.cs
+++ b/Shared/Events/IRacing/IRacingTrackInfo.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingTrackInfo : IEvent
@@ -14,5 +16,36 @@ namespace Slipstream.Shared.Events.IRacing
         public string TrackDisplayShortName { get; set; } = string.Empty;
         public string TrackConfigName { get; set; } = string.Empty;
         public string TrackType { get; internal set; } = string.Empty;
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingTrackInfo info &&
+                   EventType == info.EventType &&
+                   ExcludeFromTxrx == info.ExcludeFromTxrx &&
+                   TrackId == info.TrackId &&
+                   TrackLength == info.TrackLength &&
+                   TrackDisplayName == info.TrackDisplayName &&
+                   TrackCity == info.TrackCity &&
+                   TrackCountry == info.TrackCountry &&
+                   TrackDisplayShortName == info.TrackDisplayShortName &&
+                   TrackConfigName == info.TrackConfigName &&
+                   TrackType == info.TrackType;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1140221005;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + TrackId.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackLength);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackDisplayName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackCity);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackCountry);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackDisplayShortName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackConfigName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(TrackType);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/IRacing/IRacingWeatherInfo.cs
+++ b/Shared/Events/IRacing/IRacingWeatherInfo.cs
@@ -1,5 +1,7 @@
 #nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.IRacing
 {
     public class IRacingWeatherInfo : IEvent
@@ -23,6 +25,35 @@ namespace Slipstream.Shared.Events.IRacing
                 other.AirPressure.Equals(AirPressure) &&
                 other.RelativeHumidity.Equals(RelativeHumidity) &&
                 other.FogLevel.Equals(FogLevel);
+        }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingWeatherInfo info &&
+                   EventType == info.EventType &&
+                   ExcludeFromTxrx == info.ExcludeFromTxrx &&
+                   SessionTime == info.SessionTime &&
+                   Skies == info.Skies &&
+                   SurfaceTemp == info.SurfaceTemp &&
+                   AirTemp == info.AirTemp &&
+                   AirPressure == info.AirPressure &&
+                   RelativeHumidity == info.RelativeHumidity &&
+                   FogLevel == info.FogLevel;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1373460440;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Skies);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(SurfaceTemp);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(AirTemp);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(AirPressure);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(RelativeHumidity);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(FogLevel);
+            return hashCode;
         }
     }
 }

--- a/Shared/Events/Internal/InternalBootupEvents.cs
+++ b/Shared/Events/Internal/InternalBootupEvents.cs
@@ -1,0 +1,30 @@
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.Internal
+{
+    public class InternalBootupEvents : IEvent
+    {
+        public string EventType => "InternalBootupEvents";
+
+        public bool ExcludeFromTxrx => true;
+
+        public string Events { get; set; } = "";
+
+        public override bool Equals(object obj)
+        {
+            return obj is InternalBootupEvents events &&
+                   EventType == events.EventType &&
+                   ExcludeFromTxrx == events.ExcludeFromTxrx &&
+                   Events == events.Events;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -1012215078;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Events);
+            return hashCode;
+        }
+    }
+}

--- a/Shared/Events/Internal/InternalCommandPluginDisable.cs
+++ b/Shared/Events/Internal/InternalCommandPluginDisable.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalCommandPluginDisable : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.Internal
         public string EventType => "InternalCommandPluginDisable";
         public bool ExcludeFromTxrx => true;
         public string Id { get; set; } = "INVALID-PLUGIN-ID";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalCommandPluginDisable disable &&
+                   EventType == disable.EventType &&
+                   ExcludeFromTxrx == disable.ExcludeFromTxrx &&
+                   Id == disable.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -94409930;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalCommandPluginEnable.cs
+++ b/Shared/Events/Internal/InternalCommandPluginEnable.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalCommandPluginEnable : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.Internal
         public string EventType => "InternalCommandPluginEnable";
         public bool ExcludeFromTxrx => true;
         public string Id { get; set; } = "INVALID-PLUGIN-ID";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalCommandPluginEnable enable &&
+                   EventType == enable.EventType &&
+                   ExcludeFromTxrx == enable.ExcludeFromTxrx &&
+                   Id == enable.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -94409930;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalCommandPluginRegister.cs
+++ b/Shared/Events/Internal/InternalCommandPluginRegister.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalCommandPluginRegister : IEvent
@@ -8,5 +10,24 @@ namespace Slipstream.Shared.Events.Internal
         public bool ExcludeFromTxrx => true;
         public string Id { get; set; } = "INVALID-PLUGIN-ID";
         public string PluginName { get; set; } = "INVALID-PLUGIN-NAME";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalCommandPluginRegister register &&
+                   EventType == register.EventType &&
+                   ExcludeFromTxrx == register.ExcludeFromTxrx &&
+                   Id == register.Id &&
+                   PluginName == register.PluginName;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -172428057;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(PluginName);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalCommandPluginStates.cs
+++ b/Shared/Events/Internal/InternalCommandPluginStates.cs
@@ -1,10 +1,27 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalCommandPluginStates : IEvent
     {
         public string EventType => "InternalCommandPluginStates";
         public bool ExcludeFromTxrx => true;
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalCommandPluginStates states &&
+                   EventType == states.EventType &&
+                   ExcludeFromTxrx == states.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalCommandPluginUnregister.cs
+++ b/Shared/Events/Internal/InternalCommandPluginUnregister.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalCommandPluginUnregister : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.Internal
         public string EventType => "InternalCommandPluginUnregister";
         public bool ExcludeFromTxrx => true;
         public string Id { get; set; } = "INVALID-PLUGIN-ID";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalCommandPluginUnregister unregister &&
+                   EventType == unregister.EventType &&
+                   ExcludeFromTxrx == unregister.ExcludeFromTxrx &&
+                   Id == unregister.Id;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -94409930;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalInitialized.cs
+++ b/Shared/Events/Internal/InternalInitialized.cs
@@ -1,10 +1,27 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalInitialized : IEvent
     {
         public string EventType => "InternalInitialized";
         public bool ExcludeFromTxrx => true;
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalInitialized initialized &&
+                   EventType == initialized.EventType &&
+                   ExcludeFromTxrx == initialized.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalPluginState.cs
+++ b/Shared/Events/Internal/InternalPluginState.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalPluginState : IEvent
@@ -10,5 +12,28 @@ namespace Slipstream.Shared.Events.Internal
         public string PluginName { get; set; } = "INVALID-PLUGIN-NAME";
         public string DisplayName { get; set; } = "INVALID-DISPLAY-NAME";
         public string PluginStatus { get; set; } = "INVALID-STATE";
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalPluginState state &&
+                   EventType == state.EventType &&
+                   ExcludeFromTxrx == state.ExcludeFromTxrx &&
+                   Id == state.Id &&
+                   PluginName == state.PluginName &&
+                   DisplayName == state.DisplayName &&
+                   PluginStatus == state.PluginStatus;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1261067873;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Id);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(PluginName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(DisplayName);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(PluginStatus);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Internal/InternalReconfigured.cs
+++ b/Shared/Events/Internal/InternalReconfigured.cs
@@ -1,10 +1,27 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Internal
 {
     public class InternalReconfigured : IEvent
     {
         public string EventType => "InternalReconfigured";
         public bool ExcludeFromTxrx => true;
+
+        public override bool Equals(object? obj)
+        {
+            return obj is InternalReconfigured reconfigured &&
+                   EventType == reconfigured.EventType &&
+                   ExcludeFromTxrx == reconfigured.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Twitch/TwitchCommandSendMessage.cs
+++ b/Shared/Events/Twitch/TwitchCommandSendMessage.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Twitch
 {
     public class TwitchCommandSendMessage : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.Twitch
         public string EventType => "TwitchCommandSendMessage";
         public bool ExcludeFromTxrx => false;
         public string Message { get; set; } = string.Empty;
+
+        public override bool Equals(object? obj)
+        {
+            return obj is TwitchCommandSendMessage message &&
+                   EventType == message.EventType &&
+                   ExcludeFromTxrx == message.ExcludeFromTxrx &&
+                   Message == message.Message;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1904577466;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Twitch/TwitchConnected.cs
+++ b/Shared/Events/Twitch/TwitchConnected.cs
@@ -1,8 +1,25 @@
-﻿namespace Slipstream.Shared.Events.Twitch
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.Twitch
 {
     public class TwitchConnected : IEvent
     {
         public string EventType => "TwitchConnected";
         public bool ExcludeFromTxrx => false;
+
+        public override bool Equals(object obj)
+        {
+            return obj is TwitchConnected connected &&
+                   EventType == connected.EventType &&
+                   ExcludeFromTxrx == connected.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Twitch/TwitchDisconnected.cs
+++ b/Shared/Events/Twitch/TwitchDisconnected.cs
@@ -1,8 +1,25 @@
-﻿namespace Slipstream.Shared.Events.Twitch
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.Twitch
 {
     public class TwitchDisconnected : IEvent
     {
         public string EventType => "TwitchDisconnected";
         public bool ExcludeFromTxrx => false;
+
+        public override bool Equals(object obj)
+        {
+            return obj is TwitchDisconnected disconnected &&
+                   EventType == disconnected.EventType &&
+                   ExcludeFromTxrx == disconnected.ExcludeFromTxrx;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -441302714;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/Twitch/TwitchReceivedCommand.cs
+++ b/Shared/Events/Twitch/TwitchReceivedCommand.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.Twitch
 {
     public class TwitchReceivedCommand : IEvent
@@ -12,5 +14,32 @@ namespace Slipstream.Shared.Events.Twitch
         public bool Subscriber { get; set; }
         public bool Vip { get; set; }
         public bool Broadcaster { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is TwitchReceivedCommand command &&
+                   EventType == command.EventType &&
+                   ExcludeFromTxrx == command.ExcludeFromTxrx &&
+                   From == command.From &&
+                   Message == command.Message &&
+                   Moderator == command.Moderator &&
+                   Subscriber == command.Subscriber &&
+                   Vip == command.Vip &&
+                   Broadcaster == command.Broadcaster;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -588097615;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(From);
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Message);
+            hashCode = hashCode * -1521134295 + Moderator.GetHashCode();
+            hashCode = hashCode * -1521134295 + Subscriber.GetHashCode();
+            hashCode = hashCode * -1521134295 + Vip.GetHashCode();
+            hashCode = hashCode * -1521134295 + Broadcaster.GetHashCode();
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/UI/UIButtonTriggered.cs
+++ b/Shared/Events/UI/UIButtonTriggered.cs
@@ -1,9 +1,28 @@
-﻿namespace Slipstream.Shared.Events.UI
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.UI
 {
     public class UIButtonTriggered : IEvent
     {
         public string EventType => "UIButtonTriggered";
         public bool ExcludeFromTxrx => false;
         public string Text { get; set; } = "INVALID-NAME";
+
+        public override bool Equals(object obj)
+        {
+            return obj is UIButtonTriggered triggered &&
+                   EventType == triggered.EventType &&
+                   ExcludeFromTxrx == triggered.ExcludeFromTxrx &&
+                   Text == triggered.Text;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 25878420;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Text);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/UI/UICommandCreateButton.cs
+++ b/Shared/Events/UI/UICommandCreateButton.cs
@@ -1,9 +1,28 @@
-﻿namespace Slipstream.Shared.Events.UI
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.UI
 {
     public class UICommandCreateButton : IEvent
     {
         public string EventType => "UICommandCreateButton";
         public bool ExcludeFromTxrx => true;
         public string Text { get; set; } = "";
+
+        public override bool Equals(object obj)
+        {
+            return obj is UICommandCreateButton button &&
+                   EventType == button.EventType &&
+                   ExcludeFromTxrx == button.ExcludeFromTxrx &&
+                   Text == button.Text;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 25878420;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Text);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/UI/UICommandDeleteButton.cs
+++ b/Shared/Events/UI/UICommandDeleteButton.cs
@@ -1,9 +1,28 @@
-﻿namespace Slipstream.Shared.Events.UI
+﻿using System.Collections.Generic;
+
+namespace Slipstream.Shared.Events.UI
 {
     public class UICommandDeleteButton : IEvent
     {
         public string EventType => "UICommandDeleteButton";
         public bool ExcludeFromTxrx => true;
         public string Text { get; set; } = "";
+
+        public override bool Equals(object obj)
+        {
+            return obj is UICommandDeleteButton button &&
+                   EventType == button.EventType &&
+                   ExcludeFromTxrx == button.ExcludeFromTxrx &&
+                   Text == button.Text;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 25878420;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(Text);
+            return hashCode;
+        }
     }
 }

--- a/Shared/Events/UI/UICommandWriteToConsole.cs
+++ b/Shared/Events/UI/UICommandWriteToConsole.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using System.Collections.Generic;
+
 namespace Slipstream.Shared.Events.UI
 {
     public class UICommandWriteToConsole : IEvent
@@ -7,5 +9,22 @@ namespace Slipstream.Shared.Events.UI
         public string EventType => "UICommandWriteToConsole";
         public bool ExcludeFromTxrx => true;
         public string? Message { get; set; }
+
+        public override bool Equals(object? obj)
+        {
+            return obj is UICommandWriteToConsole console &&
+                   EventType == console.EventType &&
+                   ExcludeFromTxrx == console.ExcludeFromTxrx &&
+                   Message == console.Message;
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = 1904577466;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message);
+            return hashCode;
+        }
     }
 }

--- a/Shared/IEventFactory.cs
+++ b/Shared/IEventFactory.cs
@@ -43,6 +43,7 @@ namespace Slipstream.Shared
         InternalInitialized CreateInternalInitialized();
         InternalPluginState CreateInternalPluginState(string pluginId, string pluginName, string displayName, PluginStatusEnum pluginStatus);
         InternalReconfigured CreateInternalReconfigured();
+        InternalBootupEvents CreateInternalBootupEvents(IEvent[] events);
 
         IRacingCarCompletedLap CreateIRacingCarCompletedLap(double sessionTime, long carIdx, double time, int lapsCompleted, float? fuelDiff, bool localUser);
         IRacingCarInfo CreateIRacingCarInfo(

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -129,9 +129,11 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Backend\CapturingEventBus.cs" />
     <Compile Include="Backend\EventBus.cs" />
     <Compile Include="Backend\EventBusSubscription.cs" />
     <Compile Include="Backend\IEngine.cs" />
+    <Compile Include="Backend\IEvent.cs" />
     <Compile Include="Backend\IPluginFactory.cs" />
     <Compile Include="Backend\IPluginManager.cs" />
     <Compile Include="Backend\PluginManager.cs" />
@@ -167,6 +169,7 @@
     </Compile>
     <Compile Include="Shared\EventFactory.cs" />
     <Compile Include="Shared\Events\FileMonitor\FileMonitorScanCompleted.cs" />
+    <Compile Include="Shared\Events\Internal\InternalBootupEvents.cs" />
     <Compile Include="Shared\Events\Internal\InternalReconfigured.cs" />
     <Compile Include="Shared\Events\Internal\InternalInitialized.cs" />
     <Compile Include="Shared\Events\Internal\InternalCommandPluginStates.cs" />


### PR DESCRIPTION
Let's say, you request IRacingPlugin to send track_info() to make sure that you got these data, even if you are reloaded runtime (fx. by saving the script).

Problems: 
 - At start, we really dont need to do that, as IRacingPlugin will announce any changes it sees - including the track info
 - If multiple scripts needs track info, they will all request it. But we only need one response to fulfill their need

This PR tries to solve that.

LuaPlugin will collect any events that the Lua Script might sent at initialization (code in the outer scope). These events are packaged into a `InternalBootupEvents` event and sent. Engine will receive these and add them to a pending event list. If no further `InternalBootupEvents` are received within 0.5s, it will remove any duplicates and sent the events.

This means, that even if you create a script sending the same events multiple times, you will only see it once. Fx
```
function handle(event)
	print(event_to_json(event))
end

print("I am duplicated")
print("I am duplicated")
```

As you see here,  only one message is printed, and there was an `InternalBootupEvents` just before:

![image](https://user-images.githubusercontent.com/1899/103947904-232bf080-5139-11eb-815d-0f8a74561378.png)

For `print` this feature doesn't make much sense, but for sending commands it will. They will be added in next PR.