### PR TITLE
Lua: core:wait('name', .. ) can now redefine itself

### DIFF
--- a/Backend/Services/LuaServiceLib/CoreMethodCollection.cs
+++ b/Backend/Services/LuaServiceLib/CoreMethodCollection.cs
@@ -89,21 +89,20 @@ function event_to_json(a); return core:event_to_json(a); end
 
             private void HandleDelayedExecution(IDictionary<string, DelayedExecution> functions)
             {
-                string? deleteKey = null;
+                var triggeredFunctions = new Dictionary<string, DelayedExecution>();
 
                 foreach (var d in functions)
                 {
                     if (d.Value.TriggersAt < DateTime.Now)
                     {
-                        d.Value.Function.Call();
-                        deleteKey = d.Key;
-                        break;
+                        triggeredFunctions.Add(d.Key, d.Value);
                     }
                 }
 
-                if (deleteKey != null)
+                foreach(var d in triggeredFunctions)
                 {
-                    functions.Remove(deleteKey);
+                    functions.Remove(d.Key);
+                    d.Value.Function.Call();
                 }
             }
         }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
   - Event: Added CurrentDriverLicense to IRacingCarInfo
   - Event: Added Category to IRacingCurrentSession
   - Event: Rename LuaManagerCommandDeduplicateEvents to LuaCommandDeduplicateEvents
+  - Lua: core:wait('name', .. ) can now redefine itself within the function invoked by wait.
 
 ## [0.4.0](https://github.com/dennis/slipstream/releases/tag/v0.3.0) (2020-01-10)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.3.0...v0.4.0)


### PR DESCRIPTION
This now works:
function setup_random ()
	local delay = math.random(0,9);

	ui:print("setup_random delay = " .. delay)

	core:wait("random-wait", function()
		action(delay)

		setup_random()
	end, delay)
end

setup_random()