### PR TITLE
Audio select device

### DIFF
--- a/Backend/PluginManager.cs
+++ b/Backend/PluginManager.cs
@@ -19,6 +19,7 @@ namespace Slipstream.Backend
         private readonly IFileMonitorEventFactory FileMonitorEventFactory;
         private readonly IIRacingEventFactory IRacingEventFactory;
         private readonly ITwitchEventFactory TwitchEventFactory;
+        private readonly IAudioEventFactory AudioEventFactory;
 
         private readonly IEventBus EventBus;
         private readonly IDictionary<string, IPlugin> Plugins = new Dictionary<string, IPlugin>();
@@ -44,6 +45,7 @@ namespace Slipstream.Backend
             FileMonitorEventFactory = eventFactory.Get<IFileMonitorEventFactory>();
             IRacingEventFactory = eventFactory.Get<IIRacingEventFactory>();
             TwitchEventFactory = eventFactory.Get<ITwitchEventFactory>();
+            AudioEventFactory = eventFactory.Get<IAudioEventFactory>();
             EventBus = eventBus;
             ApplicationConfiguration = applicationConfiguration;
             StateService = stateService;
@@ -202,7 +204,7 @@ namespace Slipstream.Backend
             {
                 "FileMonitorPlugin" => new FileMonitorPlugin(id, FileMonitorEventFactory, eventBus, ApplicationConfiguration),
                 "LuaManagerPlugin" => new LuaManagerPlugin(id, FileMonitorEventFactory, eventBus, this, this, EventSerdeService),
-                "AudioPlugin" => new AudioPlugin(id, Logger.ForContext(typeof(AudioPlugin)), ApplicationConfiguration),
+                "AudioPlugin" => new AudioPlugin(id, Logger.ForContext(typeof(AudioPlugin)), eventBus, AudioEventFactory, ApplicationConfiguration),
                 "IRacingPlugin" => new IRacingPlugin(id, IRacingEventFactory, eventBus),
                 "TwitchPlugin" => new TwitchPlugin(id, Logger.ForContext(typeof(TwitchPlugin)), TwitchEventFactory, eventBus, ApplicationConfiguration),
                 "TransmitterPlugin" => new TransmitterPlugin(id, Logger.ForContext(typeof(TransmitterPlugin)), InternalEventFactory, eventBus, TxrxService, ApplicationConfiguration),

--- a/Backend/Plugins/AudioPlugin.cs
+++ b/Backend/Plugins/AudioPlugin.cs
@@ -1,7 +1,10 @@
 using NAudio.Wave;
 using Serilog;
 using Slipstream.Shared;
+using Slipstream.Shared.Events.Audio;
+using Slipstream.Shared.Factories;
 using System;
+using System.IO;
 using System.Speech.Synthesis;
 using System.Threading;
 using EventHandler = Slipstream.Shared.EventHandler;
@@ -15,10 +18,15 @@ namespace Slipstream.Backend.Plugins
         private readonly ILogger Logger;
         private readonly string Path;
         private readonly SpeechSynthesizer Synthesizer;
+        private readonly IAudioEventFactory EventFactory;
+        private readonly IEventBus EventBus;
+        private WaveOutEvent OutputDevice = new WaveOutEvent();
 
-        public AudioPlugin(string id, ILogger logger, IAudioConfiguration audioConfiguration) : base(id, "AudioPlugin", "AudioPlugin", id, true)
+        public AudioPlugin(string id, ILogger logger, IEventBus eventBus, IAudioEventFactory eventFactory, IAudioConfiguration audioConfiguration) : base(id, "AudioPlugin", "AudioPlugin", id, true)
         {
             Logger = logger;
+            EventBus = eventBus;
+            EventFactory = eventFactory;
 
             Path = audioConfiguration.AudioPath;
 
@@ -29,6 +37,29 @@ namespace Slipstream.Backend.Plugins
 
             Audio.OnAudioCommandSay += (_, e) => OnAudioCommandSay(e.Event);
             Audio.OnAudioCommandPlay += (_, e) => OnAudioCommandPlay(e.Event);
+            Audio.OnAudioCommandSendDevices += (_, e) => OnAudioCommandSendDevices(e.Event);
+            Audio.OnAudioCommandSetOutputDevice += (_, e) => OnAudioCommandSetOutputDevice(e.Event);
+        }
+
+        private void OnAudioCommandSetOutputDevice(AudioCommandSetOutputDevice @event)
+        {
+            if (@event.PluginId != Id)
+                return;
+
+            OutputDevice = new WaveOutEvent() { DeviceNumber = @event.DeviceIdx };
+        }
+
+        private void OnAudioCommandSendDevices(AudioCommandSendDevices @event)
+        {
+            if (@event.PluginId != Id)
+                return;
+
+            for (int n = -1; n < WaveOut.DeviceCount; n++)
+            {
+                var caps = WaveOut.GetCapabilities(n);
+
+                EventBus.PublishEvent(EventFactory.CreateAudioOutputDevice(Id, caps.ProductName, n));
+            }
         }
 
         private void OnAudioCommandPlay(Shared.Events.Audio.AudioCommandPlay @event)
@@ -43,14 +74,8 @@ namespace Slipstream.Backend.Plugins
             try
             {
                 using var audioFile = new AudioFileReader(filePath);
-                using var outputDevice = new WaveOutEvent();
-                outputDevice.Init(audioFile);
-                outputDevice.Volume = (float)volume;
-                outputDevice.Play();
-                while (outputDevice.PlaybackState == PlaybackState.Playing)
-                {
-                    Thread.Sleep(100);
-                }
+
+                Play(new AudioFileReader(filePath), (float)volume);
             }
             catch (Exception ex)
             {
@@ -63,8 +88,26 @@ namespace Slipstream.Backend.Plugins
             if (@event.PluginId != Id)
                 return;
 
-            Synthesizer.Volume = Math.Min((int)(100 * @event.Volume), 100);
+            using var stream = new MemoryStream();
+
+            Synthesizer.SetOutputToWaveStream(stream);
             Synthesizer.Speak(@event.Message);
+
+            stream.Flush();
+            stream.Seek(0, SeekOrigin.Begin);
+
+            Play(new WaveFileReader(stream), (float)@event.Volume);
+        }
+
+        private void Play(WaveStream stream, float volume)
+        {
+            OutputDevice.Init(stream);
+            OutputDevice.Volume = volume;
+            OutputDevice.Play();
+            while (OutputDevice.PlaybackState == PlaybackState.Playing)
+            {
+                Thread.Sleep(100);
+            }
         }
     }
 }

--- a/Backend/Services/LuaServiceLib/AudioMethodCollection.cs
+++ b/Backend/Services/LuaServiceLib/AudioMethodCollection.cs
@@ -30,21 +30,21 @@ namespace Slipstream.Backend.Services.LuaServiceLib
             {
                 lua["audio"] = this;
                 lua.DoString(@"
-function say(a,b); audio:say(a,b); end
-function play(a,b); audio:play(a,b); end
+function say(plugin_id, message, volume); audio:say(plugin_id,message, volume); end
+function play(plugin_id, filename, volume); audio:play(plugin_id, filename, volume); end
 ");
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
-            public void say(string message, float volume)
+            public void say(string pluginId, string message, float volume)
             {
-                EventBus.PublishEvent(EventFactory.CreateAudioCommandSay(message, volume));
+                EventBus.PublishEvent(EventFactory.CreateAudioCommandSay(pluginId, message, volume));
             }
 
             [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
-            public void play(string filename, float volume)
+            public void play(string pluginId, string filename, float volume)
             {
-                EventBus.PublishEvent(EventFactory.CreateAudioCommandPlay(filename, volume));
+                EventBus.PublishEvent(EventFactory.CreateAudioCommandPlay(pluginId, filename, volume));
             }
         }
     }

--- a/Backend/Services/LuaServiceLib/AudioMethodCollection.cs
+++ b/Backend/Services/LuaServiceLib/AudioMethodCollection.cs
@@ -32,6 +32,7 @@ namespace Slipstream.Backend.Services.LuaServiceLib
                 lua.DoString(@"
 function say(plugin_id, message, volume); audio:say(plugin_id,message, volume); end
 function play(plugin_id, filename, volume); audio:play(plugin_id, filename, volume); end
+
 ");
             }
 
@@ -45,6 +46,18 @@ function play(plugin_id, filename, volume); audio:play(plugin_id, filename, volu
             public void play(string pluginId, string filename, float volume)
             {
                 EventBus.PublishEvent(EventFactory.CreateAudioCommandPlay(pluginId, filename, volume));
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
+            public void send_devices(string pluginId)
+            {
+                EventBus.PublishEvent(EventFactory.CreateAudioCommandSendDevices(pluginId));
+            }
+
+            [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
+            public void set_output(string pluginId, int deviceIdx)
+            {
+                EventBus.PublishEvent(EventFactory.CreateAudioCommandSetOutputDevice(pluginId, deviceIdx));
             }
         }
     }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@
   - Event: Added Category to IRacingCurrentSession
   - Event: Rename LuaManagerCommandDeduplicateEvents to LuaCommandDeduplicateEvents
   - Lua: core:wait('name', .. ) can now redefine itself within the function invoked by wait.
+  - lua: Adds audio:send_devices(..), audio:set_output(..) to control which output device to use
+  - lua: Changed audio:play(..), audio:say(..) with another arguments to decide which plugin to use
+  - events: Adds AudioCommandSendDevices, AudioCommandSetOutputDevice and AudioOutputDevice
 
 ## [0.4.0](https://github.com/dennis/slipstream/releases/tag/v0.3.0) (2020-01-10)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.3.0...v0.4.0)

--- a/Shared/EventHandlers/Audio.cs
+++ b/Shared/EventHandlers/Audio.cs
@@ -18,9 +18,21 @@ namespace Slipstream.Shared.EventHandlers
 
         public delegate void OnAudioCommandSayHandler(EventHandler source, EventHandlerArgs<AudioCommandSay> e);
 
+        public delegate void OnAudioCommandSendDevicesHandler(EventHandler source, EventHandlerArgs<AudioCommandSendDevices> e);
+
+        public delegate void OnAudioCommandSetOutputDeviceHandler(EventHandler source, EventHandlerArgs<AudioCommandSetOutputDevice> e);
+
+        public delegate void OnAudioOutputDeviceHandler(EventHandler source, EventHandlerArgs<AudioOutputDevice> e);
+
         public event OnAudioCommandPlayHandler? OnAudioCommandPlay;
 
         public event OnAudioCommandSayHandler? OnAudioCommandSay;
+
+        public event OnAudioCommandSendDevicesHandler? OnAudioCommandSendDevices;
+
+        public event OnAudioCommandSetOutputDeviceHandler? OnAudioCommandSetOutputDevice;
+
+        public event OnAudioOutputDeviceHandler? OnAudioOutputDevice;
 
         public IEventHandler.HandledStatus HandleEvent(IEvent @event)
         {
@@ -40,6 +52,36 @@ namespace Slipstream.Shared.EventHandlers
                     if (OnAudioCommandPlay != null)
                     {
                         OnAudioCommandPlay.Invoke(Parent, new EventHandlerArgs<AudioCommandPlay>(tev));
+                        return IEventHandler.HandledStatus.Handled;
+                    }
+                    else
+                    {
+                        return IEventHandler.HandledStatus.UseDefault;
+                    }
+                case AudioCommandSendDevices tev:
+                    if (OnAudioCommandSendDevices != null)
+                    {
+                        OnAudioCommandSendDevices.Invoke(Parent, new EventHandlerArgs<AudioCommandSendDevices>(tev));
+                        return IEventHandler.HandledStatus.Handled;
+                    }
+                    else
+                    {
+                        return IEventHandler.HandledStatus.UseDefault;
+                    }
+                case AudioOutputDevice tev:
+                    if (OnAudioOutputDevice != null)
+                    {
+                        OnAudioOutputDevice.Invoke(Parent, new EventHandlerArgs<AudioOutputDevice>(tev));
+                        return IEventHandler.HandledStatus.Handled;
+                    }
+                    else
+                    {
+                        return IEventHandler.HandledStatus.UseDefault;
+                    }
+                case AudioCommandSetOutputDevice tev:
+                    if (OnAudioCommandSetOutputDevice != null)
+                    {
+                        OnAudioCommandSetOutputDevice.Invoke(Parent, new EventHandlerArgs<AudioCommandSetOutputDevice>(tev));
                         return IEventHandler.HandledStatus.Handled;
                     }
                     else

--- a/Shared/Events/Audio/AudioCommandPlay.cs
+++ b/Shared/Events/Audio/AudioCommandPlay.cs
@@ -9,8 +9,9 @@ namespace Slipstream.Shared.Events.Audio
         public string EventType => "AudioCommandPlay";
         public bool ExcludeFromTxrx => true;
         public ulong Uptime { get; set; }
-        public string? Filename { get; set; }
-        public float? Volume { get; set; }
+        public string PluginId { get; set; } = "INVAILD-PLUGIN-ID";
+        public string Filename { get; set; } = string.Empty;
+        public float Volume { get; set; } = 1.0f;
 
         public override bool Equals(object? obj)
         {
@@ -24,10 +25,10 @@ namespace Slipstream.Shared.Events.Audio
         public override int GetHashCode()
         {
             int hashCode = 2126878269;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
-            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Filename);
-            hashCode = hashCode * -1521134295 + Volume.GetHashCode();
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = (hashCode * -1521134295) + ExcludeFromTxrx.GetHashCode();
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string?>.Default.GetHashCode(Filename);
+            hashCode = (hashCode * -1521134295) + Volume.GetHashCode();
             return hashCode;
         }
     }

--- a/Shared/Events/Audio/AudioCommandPlay.cs
+++ b/Shared/Events/Audio/AudioCommandPlay.cs
@@ -7,7 +7,7 @@ namespace Slipstream.Shared.Events.Audio
     public class AudioCommandPlay : IEvent
     {
         public string EventType => "AudioCommandPlay";
-        public bool ExcludeFromTxrx => true;
+        public bool ExcludeFromTxrx => false;
         public ulong Uptime { get; set; }
         public string PluginId { get; set; } = "INVAILD-PLUGIN-ID";
         public string Filename { get; set; } = string.Empty;

--- a/Shared/Events/Audio/AudioCommandSay.cs
+++ b/Shared/Events/Audio/AudioCommandSay.cs
@@ -7,7 +7,7 @@ namespace Slipstream.Shared.Events.Audio
     public class AudioCommandSay : IEvent
     {
         public string EventType => "AudioCommandSay";
-        public bool ExcludeFromTxrx => true;
+        public bool ExcludeFromTxrx => false;
         public ulong Uptime { get; set; }
         public string PluginId { get; set; } = "INVAILD-PLUGIN-ID";
         public string Message { get; set; } = string.Empty;

--- a/Shared/Events/Audio/AudioCommandSay.cs
+++ b/Shared/Events/Audio/AudioCommandSay.cs
@@ -9,8 +9,9 @@ namespace Slipstream.Shared.Events.Audio
         public string EventType => "AudioCommandSay";
         public bool ExcludeFromTxrx => true;
         public ulong Uptime { get; set; }
-        public string? Message { get; set; }
-        public float? Volume { get; set; }
+        public string PluginId { get; set; } = "INVAILD-PLUGIN-ID";
+        public string Message { get; set; } = string.Empty;
+        public float Volume { get; set; } = 1.0f;
 
         public override bool Equals(object? obj)
         {
@@ -24,10 +25,10 @@ namespace Slipstream.Shared.Events.Audio
         public override int GetHashCode()
         {
             int hashCode = 1098881401;
-            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
-            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
-            hashCode = hashCode * -1521134295 + EqualityComparer<string?>.Default.GetHashCode(Message);
-            hashCode = hashCode * -1521134295 + Volume.GetHashCode();
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = (hashCode * -1521134295) + ExcludeFromTxrx.GetHashCode();
+            hashCode = (hashCode * -1521134295) + EqualityComparer<string?>.Default.GetHashCode(Message);
+            hashCode = (hashCode * -1521134295) + Volume.GetHashCode();
             return hashCode;
         }
     }

--- a/Shared/Events/Audio/AudioCommandSendDevices.cs
+++ b/Shared/Events/Audio/AudioCommandSendDevices.cs
@@ -1,0 +1,9 @@
+﻿namespace Slipstream.Shared.Events.Audio
+{
+    public class AudioCommandSendDevices : IEvent
+    {
+        public string EventType => "AudioCommandSendDevices";
+        public bool ExcludeFromTxrx => false;
+        public string PluginId { get; set; } = "INVALID-PLUGIN-ID";
+    }
+}

--- a/Shared/Events/Audio/AudioCommandSetOutputDevice.cs
+++ b/Shared/Events/Audio/AudioCommandSetOutputDevice.cs
@@ -1,0 +1,10 @@
+﻿namespace Slipstream.Shared.Events.Audio
+{
+    public class AudioCommandSetOutputDevice : IEvent
+    {
+        public string EventType => "AudioCommandSetOutputDevice";
+        public bool ExcludeFromTxrx => false;
+        public string PluginId { get; set; } = "INVALID-PLUGIN-ID";
+        public int DeviceIdx { get; set; } = -1;
+    }
+}

--- a/Shared/Events/Audio/AudioOutputDevice.cs
+++ b/Shared/Events/Audio/AudioOutputDevice.cs
@@ -1,0 +1,14 @@
+﻿#nullable enable
+
+
+namespace Slipstream.Shared.Events.Audio
+{
+    public class AudioOutputDevice : IEvent
+    {
+        public string EventType => "AudioOutputDevice";
+        public bool ExcludeFromTxrx => false;
+        public string PluginId { get; set; } = "INVAILD-PLUGIN-ID";
+        public string Product { get; set; } = string.Empty;
+        public int DeviceIdx { get; set; } = -1;
+    }
+}

--- a/Shared/Factories/AudioEventFactory.cs
+++ b/Shared/Factories/AudioEventFactory.cs
@@ -6,14 +6,14 @@ namespace Slipstream.Shared.Factories
 {
     public class AudioEventFactory : IAudioEventFactory
     {
-        public AudioCommandPlay CreateAudioCommandPlay(string filename, float? volume)
+        public AudioCommandPlay CreateAudioCommandPlay(string pluginId, string filename, float volume)
         {
-            return new AudioCommandPlay { Filename = filename, Volume = volume };
+            return new AudioCommandPlay { PluginId = pluginId, Filename = filename, Volume = volume };
         }
 
-        public AudioCommandSay CreateAudioCommandSay(string message, float? volume)
+        public AudioCommandSay CreateAudioCommandSay(string pluginId, string message, float volume)
         {
-            return new AudioCommandSay { Message = message, Volume = volume };
+            return new AudioCommandSay { PluginId = pluginId, Message = message, Volume = volume };
         }
     }
 }

--- a/Shared/Factories/AudioEventFactory.cs
+++ b/Shared/Factories/AudioEventFactory.cs
@@ -15,5 +15,20 @@ namespace Slipstream.Shared.Factories
         {
             return new AudioCommandSay { PluginId = pluginId, Message = message, Volume = volume };
         }
+
+        public AudioCommandSendDevices CreateAudioCommandSendDevices(string pluginId)
+        {
+            return new AudioCommandSendDevices{ PluginId = pluginId };
+        }
+
+        public AudioOutputDevice CreateAudioOutputDevice(string pluginId, string product, int deviceIdx)
+        {
+            return new AudioOutputDevice { DeviceIdx = deviceIdx, PluginId = pluginId, Product = product };
+        }
+
+        public AudioCommandSetOutputDevice CreateAudioCommandSetOutputDevice(string pluginId, int deviceIdx)
+        {
+            return new AudioCommandSetOutputDevice { PluginId = pluginId, DeviceIdx = deviceIdx };
+        }
     }
 }

--- a/Shared/Factories/IAudioEventFactory.cs
+++ b/Shared/Factories/IAudioEventFactory.cs
@@ -6,7 +6,7 @@ namespace Slipstream.Shared.Factories
 {
     public interface IAudioEventFactory
     {
-        AudioCommandPlay CreateAudioCommandPlay(string filename, float? volume);
-        AudioCommandSay CreateAudioCommandSay(string message, float? volume);
+        AudioCommandPlay CreateAudioCommandPlay(string pluginId, string filename, float volume);
+        AudioCommandSay CreateAudioCommandSay(string pluginId, string message, float volume);
     }
 }

--- a/Shared/Factories/IAudioEventFactory.cs
+++ b/Shared/Factories/IAudioEventFactory.cs
@@ -7,6 +7,13 @@ namespace Slipstream.Shared.Factories
     public interface IAudioEventFactory
     {
         AudioCommandPlay CreateAudioCommandPlay(string pluginId, string filename, float volume);
+
         AudioCommandSay CreateAudioCommandSay(string pluginId, string message, float volume);
+
+        AudioCommandSendDevices CreateAudioCommandSendDevices(string pluginId);
+
+        AudioOutputDevice CreateAudioOutputDevice(string pluginId, string product, int deviceIdx);
+
+        AudioCommandSetOutputDevice CreateAudioCommandSetOutputDevice(string pluginId, int deviceIdx);
     }
 }

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -178,6 +178,9 @@
     <Compile Include="Shared\EventHandlers\Playback.cs" />
     <Compile Include="Shared\Events\Playback\PlaybackCommandInjectEvents.cs" />
     <Compile Include="Shared\Events\Playback\PlaybackCommandSaveEvents.cs" />
+    <Compile Include="Shared\Events\Audio\AudioCommandSetOutputDevice.cs" />
+    <Compile Include="Shared\Events\Audio\AudioCommandSendDevices.cs" />
+    <Compile Include="Shared\Events\Audio\AudioOutputDevice.cs" />
     <Compile Include="Shared\Factories\AudioEventFactory.cs" />
     <Compile Include="Shared\Factories\IInternalEventFactory.cs" />
     <Compile Include="Shared\Factories\IPlaybackEventFactory.cs" />

--- a/docs/events.md
+++ b/docs/events.md
@@ -40,12 +40,13 @@ Requests a mp3/wave files to be played. Filename is relative to the audio direct
 |:----------------|:-------:|:-----------------------------------------------------------|
 | EventType       | string  | `AudioCommandPlay` (constant)                              |
 | ExcludeFromTxrx | boolean | true (constant)                                            |
+| PluginId        | string  | Which plugin should play the sound                         |
 | Filename        | string  | Filename to play, relative to the audio directory          |
 | Volume          | numeric | Value from 0 .. 1, being from muted (0) to full volume (1) |
 
 
 **JSON Example:** 
-`{"EventType": "AudioCommandPlay", "ExcludeFromTxrx": true,"Uptime":299, "Filename": "Ding-sound-effect.mp3", "Volume": 1}`
+`{"EventType": "AudioCommandPlay", "ExcludeFromTxrx": true, "Uptime":299, "PluginId": "AudioDefault", "Filename": "Ding-sound-effect.mp3", "Volume": 1}`
 </details>
 
 <details><summary>AudioCommandSay</summary><br />
@@ -55,11 +56,12 @@ Request message to read out loud using Windows text-to-speech
 |:----------------|:-------:|:-----------------------------------------------------------|
 | EventType       | string  | `AudioCommandSay` (constant)                               |
 | ExcludeFromTxrx | boolean | true (constant)                                            |
+| PluginId        | string  | Which plugin should play the sound                         |
 | Message         | string  | Text to speak                                              |
 | Volume          | numeric | Value from 0 .. 1, being from muted (0) to full volume (1) |
 
 **JSON Example:** 
-`{"EventType": "AudioCommandSay",  "ExcludeFromTxrx": true,"Uptime":299,  "Message": "Slipstream ready",  "Volume": 0.800000012}`
+`{"EventType": "AudioCommandSay",  "ExcludeFromTxrx": true, "Uptime":299,  "PluginId": "AudioDefault",  "Message": "Slipstream ready",  "Volume": 0.800000012}`
 </details>
 
 ## FileMonitor
@@ -162,7 +164,7 @@ scripts.
 
 | Name            | Type    | Description                                            |
 |:----------------|:-------:|:-------------------------------------------------------|
-| EventType       | string  | `LuaCommandDeduplicateEvents` (constant)          |
+| EventType       | string  | `LuaCommandDeduplicateEvents` (constant)               |
 | ExcludeFromTxrx | boolean | true (constant)                                        |
 | Events          | string  | JSON serialized version of the events. Separated by \n |
 

--- a/docs/events.md
+++ b/docs/events.md
@@ -39,8 +39,8 @@ Requests a mp3/wave files to be played. Filename is relative to the audio direct
 | Name            | Type    | Description                                                |
 |:----------------|:-------:|:-----------------------------------------------------------|
 | EventType       | string  | `AudioCommandPlay` (constant)                              |
-| ExcludeFromTxrx | boolean | true (constant)                                            |
-| PluginId        | string  | Which plugin should play the sound                         |
+| ExcludeFromTxrx | boolean | false (constant)                                           |
+| PluginId        | string  | Which plugin should act                                    |
 | Filename        | string  | Filename to play, relative to the audio directory          |
 | Volume          | numeric | Value from 0 .. 1, being from muted (0) to full volume (1) |
 
@@ -55,13 +55,56 @@ Request message to read out loud using Windows text-to-speech
 | Name            | Type    | Description                                                |
 |:----------------|:-------:|:-----------------------------------------------------------|
 | EventType       | string  | `AudioCommandSay` (constant)                               |
-| ExcludeFromTxrx | boolean | true (constant)                                            |
-| PluginId        | string  | Which plugin should play the sound                         |
+| ExcludeFromTxrx | boolean | false (constant)                                           |
+| PluginId        | string  | Which plugin should act                                    |
 | Message         | string  | Text to speak                                              |
 | Volume          | numeric | Value from 0 .. 1, being from muted (0) to full volume (1) |
 
 **JSON Example:** 
 `{"EventType": "AudioCommandSay",  "ExcludeFromTxrx": true, "Uptime":299,  "PluginId": "AudioDefault",  "Message": "Slipstream ready",  "Volume": 0.800000012}`
+</details>
+
+<details><summary>AudioCommandSendDevices</summary><br />
+
+Send known devices via `AudioOutputDevice`.
+
+| Name            | Type    | Description                          |
+|:----------------|:-------:|:-------------------------------------|
+| EventType       | string  | `AudioCommandSendDevices` (constant) |
+| ExcludeFromTxrx | boolean | false (constant)                     |
+| PluginId        | string  | Which plugin should act              |
+
+**JSON Example:** 
+`{"EventType":"AudioCommandSendDevices","ExcludeFromTxrx":false,"PluginId":"AudioPlugin:Default"}`
+</details>
+
+<details><summary>AudioCommandSetOutputDevice</summary><br />
+
+| Name            | Type    | Description                              |
+|:----------------|:-------:|:-----------------------------------------|
+| EventType       | string  | `AudioCommandSetOutputDevice` (constant) |
+| ExcludeFromTxrx | boolean | false (constant)                         |
+| PluginId        | string  | Which plugin should act                  |
+| DeviceIdx       | int     | DeviceIdx to use for this plugin         |
+
+**JSON Example:** 
+`{"EventType":"AudioCommandSetOutputDevice","ExcludeFromTxrx":false,"PluginId":"AudioPlugin:Other","DeviceIdx":2}`
+</details>
+
+<details><summary>AudioOutputDevice</summary><br />
+
+A output device found. Note: Device with DeviceIdx -1 is the default device.
+
+| Name            | Type    | Description                                     |
+|:----------------|:-------:|:------------------------------------------------|
+| EventType       | string  | `AudioOutputDevice` (constant)                  |
+| ExcludeFromTxrx | boolean | true (constant)                                 |
+| PluginId        | string  | Plugin responding                               |
+| Product         | string  | Product as returned by Windows                  |
+| DeviceIdx       | int     | Device index, use this for selecting the device |
+
+**JSON Example:** 
+`{"EventType":"AudioOutputDevice","ExcludeFromTxrx":true,"PluginId":"AudioPlugin:Default","Product":"Microsoft Sound Mapper","DeviceIdx":-1}`
 </details>
 
 ## FileMonitor

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -4,11 +4,12 @@
 
 These are provided by AudioPlugin.
 
-<details><summary>audio:say(message, volume)</summary><br />
+<details><summary>audio:say(plugin_id, message, volume)</summary><br />
 Use Windows text-to-speech to say message. 
 
 | Parameter | Type        | Description                  |
 |:----------|:-----------:|:-----------------------------|
+| plugin_id | string      | which plugin should act      |
 | message   | string      | What to say                  |
 | volume    | number 0..1 | 0 is muted, 1 is full volume |
 
@@ -21,11 +22,12 @@ This function publishes `AudioCommandSay` event, that is handled by AudioPlugin.
 This function is aliased as ``say`` (deprecated)
 </details>
 
-<details><summary>audio:play(filename, volume)</summary><br />
+<details><summary>audio:play(plugin_id, filename, volume)</summary><br />
 Plays a wav/mp3 file relative to the audio directory (Open it via menu Help -> Open Audio Directory). 
 
 | Parameter | Type        | Description                  |
 |:----------|:-----------:|:-----------------------------|
+| plugin_id | string      | which plugin should act      |
 | filename  | string      | file to play                 |
 | volume    | number 0..1 | 0 is muted, 1 is full volume |
 

--- a/docs/lua.md
+++ b/docs/lua.md
@@ -5,7 +5,7 @@
 These are provided by AudioPlugin.
 
 <details><summary>audio:say(plugin_id, message, volume)</summary><br />
-Use Windows text-to-speech to say message. 
+Use Windows text-to-speech to speak message. 
 
 | Parameter | Type        | Description                  |
 |:----------|:-----------:|:-----------------------------|
@@ -14,7 +14,7 @@ Use Windows text-to-speech to say message.
 | volume    | number 0..1 | 0 is muted, 1 is full volume |
 
 ```lua
-audio:say("Hello", 0.8)
+audio:say("AudioPlugin", "Hello", 0.8)
 ```
 
 This function publishes `AudioCommandSay` event, that is handled by AudioPlugin.
@@ -32,12 +32,44 @@ Plays a wav/mp3 file relative to the audio directory (Open it via menu Help -> O
 | volume    | number 0..1 | 0 is muted, 1 is full volume |
 
 ```lua
-audio:play("ding-sound-effect.mp3", 1.0)
+audio:play("AudioPlugin", "ding-sound-effect.mp3", 1.0)
 ```
 
 This function publishes `AudioCommandPlay` event, that is handled by AudioPlugin.
 
 This function is aliased as ``play`` (deprecated)
+</details>
+
+<details><summary>audio:send_devices(plugin_id)</summary><br />
+
+Request that `AudioOutputDevice` is sent for each audio device found.
+
+| Parameter | Type        | Description                  |
+|:----------|:-----------:|:-----------------------------|
+| plugin_id | string      | which plugin should act      |
+
+```lua
+audio:send_devices("AudioPlugin")
+```
+
+This function publishes `AudioCommandSendDevices` event, that is handled by AudioPlugin.
+
+</details>
+
+<details><summary>audio:set_output(plugin_id, device_idx)</summary><br />
+Change output for a plugin to another device. All plugins starts using 
+default audio output, but can be changed via this. 
+
+| Parameter  | Type   | Description                       |
+|:-----------|:------:|:----------------------------------|
+| plugin_id  | string | which plugin should act           |
+| device_idx | number | what device to use. -1 is default |
+
+```lua
+audio:set_output("AudioPlugin", 2)
+```
+
+This function publishes `AudioCommandSetOutputDevice` event, that is handled by AudioPlugin.
 </details>
 
 ## Core


### PR DESCRIPTION
Solves https://github.com/dennis/slipstream/issues/34

***Example***

Change *init-0.4.0*
```
register_plugin("AudioPlugin:Default", "AudioPlugin")
register_plugin("AudioPlugin:Other", "AudioPlugin")
```


*scripts/audio.lua*
```
audio:send_devices("AudioPlugin:Default") -- you will receive AudioOutputDevice events here
audio:set_output("AudioPlugin:Other", 2) -- "2" is a device reported by the above command
audio:say("AudioPlugin:Other", "Hello", 0.3)
audio:play("AudioPlugin:Default", "aww-sound-effect.mp3", 0.3)
```

Note: This breaks all `say` and `play`, as there now is a 3rd argument, that decides which plugin to use