### PR TITLE
Refactor Event handlers

### DIFF
--- a/Backend/IPlugin.cs
+++ b/Backend/IPlugin.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using Slipstream.Shared;
+using System;
 
 #nullable enable
 
@@ -17,13 +18,16 @@ namespace Slipstream.Backend
         }
 
         public delegate void OnStateChangedHandler(IPlugin source, EventHandlerArgs<IPlugin> e);
+
         public event OnStateChangedHandler? OnStateChanged;
+
         public string Id { get; }
         public string Name { get; }
         public string DisplayName { get; }
         public string WorkerName { get; }
-        public Shared.EventHandler EventHandler { get; }
+        public IEventHandlerController EventHandlerController { get; }
         public bool Reconfigurable { get; }
+
         void Loop();
     }
 }

--- a/Backend/PluginWorker.cs
+++ b/Backend/PluginWorker.cs
@@ -60,7 +60,7 @@ namespace Slipstream.Backend
                     {
                         foreach (var plugin in Plugins)
                         {
-                            plugin.EventHandler.HandleEvent(e);
+                            plugin.EventHandlerController.HandleEvent(e);
                         }
                     }
                 }

--- a/Backend/Plugins/AudioPlugin.cs
+++ b/Backend/Plugins/AudioPlugin.cs
@@ -9,7 +9,6 @@ using System;
 using System.IO;
 using System.Speech.Synthesis;
 using System.Threading;
-using EventHandler = Slipstream.Shared.EventHandler;
 
 #nullable enable
 
@@ -33,7 +32,7 @@ namespace Slipstream.Backend.Plugins
                 .PermitLong("output");
         }
 
-        public AudioPlugin(string id, ILogger logger, IEventBus eventBus, IAudioEventFactory eventFactory, Parameters configuration) : base(id, "AudioPlugin", id, id, true)
+        public AudioPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IEventBus eventBus, IAudioEventFactory eventFactory, Parameters configuration) : base(eventHandlerController, id, "AudioPlugin", id, id, true)
         {
             Logger = logger;
             EventBus = eventBus;
@@ -55,7 +54,7 @@ namespace Slipstream.Backend.Plugins
                 OutputDevice = new WaveOutEvent() { DeviceNumber = outputDeviceIdx };
             }
 
-            var Audio = EventHandler.Get<Shared.EventHandlers.Audio>();
+            var Audio = EventHandlerController.Get<Shared.EventHandlers.Audio>();
 
             Audio.OnAudioCommandSay += (_, e) => OnAudioCommandSay(e.Event);
             Audio.OnAudioCommandPlay += (_, e) => OnAudioCommandPlay(e.Event);

--- a/Backend/Plugins/BasePlugin.cs
+++ b/Backend/Plugins/BasePlugin.cs
@@ -1,5 +1,7 @@
 ﻿#nullable enable
 
+using Slipstream.Shared;
+
 namespace Slipstream.Backend.Plugins
 {
     public class BasePlugin : IPlugin
@@ -33,10 +35,11 @@ namespace Slipstream.Backend.Plugins
             set { workerName = value; OnStateChanged?.Invoke(this, new IPlugin.EventHandlerArgs<IPlugin>(this)); }
         }
 
-        public Shared.EventHandler EventHandler { get; } = new Shared.EventHandler();
+        public IEventHandlerController EventHandlerController { get; }
 
-        public BasePlugin(string id, string name, string displayName, string workerName, bool reconfigurable = false)
+        public BasePlugin(IEventHandlerController eventHandlerController, string id, string name, string displayName, string workerName, bool reconfigurable = false)
         {
+            EventHandlerController = eventHandlerController;
             Id = id;
             Name = name;
             DisplayName = displayName;

--- a/Backend/Plugins/FileMonitorPlugin.cs
+++ b/Backend/Plugins/FileMonitorPlugin.cs
@@ -24,12 +24,12 @@ namespace Slipstream.Backend.Plugins
                 .PermitArray("paths", (a) => a.RequireString());
         }
 
-        public FileMonitorPlugin(string id, IFileMonitorEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(id, "FileMonitorPlugin", id, "Core", true)
+        public FileMonitorPlugin(IEventHandlerController eventHandlerController, string id, IFileMonitorEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(eventHandlerController, id, "FileMonitorPlugin", id, "Core", true)
         {
             EventFactory = eventFactory;
             EventBus = eventBus;
 
-            var FileMonitor = EventHandler.Get<Slipstream.Shared.EventHandlers.FileMonitor>();
+            var FileMonitor = EventHandlerController.Get<Slipstream.Shared.EventHandlers.FileMonitor>();
             FileMonitor.OnFileMonitorCommandScan += (s, e) => ScanExistingFiles();
 
             ConfigurationValidator.Validate(configuration);

--- a/Backend/Plugins/IRacingPlugin.cs
+++ b/Backend/Plugins/IRacingPlugin.cs
@@ -8,7 +8,6 @@ using System.Diagnostics;
 using System.Linq;
 using System.Threading;
 using static Slipstream.Shared.Factories.IIRacingEventFactory;
-using EventHandler = Slipstream.Shared.EventHandler;
 
 #nullable enable
 
@@ -101,12 +100,12 @@ namespace Slipstream.Backend.Plugins
         private bool SendSessionState = false;
         private bool SendRaceFlags = false;
 
-        public IRacingPlugin(string id, IIRacingEventFactory eventFactory, IEventBus eventBus) : base(id, "IRacingPlugin", id, "IRacingPlugin")
+        public IRacingPlugin(IEventHandlerController eventHandlerController, string id, IIRacingEventFactory eventFactory, IEventBus eventBus) : base(eventHandlerController, id, "IRacingPlugin", id, "IRacingPlugin")
         {
             EventFactory = eventFactory;
             EventBus = eventBus;
 
-            var IRacingEventHandler = EventHandler.Get<Slipstream.Shared.EventHandlers.IRacing>();
+            var IRacingEventHandler = EventHandlerController.Get<Slipstream.Shared.EventHandlers.IRacing>();
 
             IRacingEventHandler.OnIRacingCommandSendCarInfo += (s, e) => SendCarInfo = true;
             IRacingEventHandler.OnIRacingCommandSendTrackInfo += (s, e) => SendTrackInfo = true;

--- a/Backend/Plugins/LuaPlugin.cs
+++ b/Backend/Plugins/LuaPlugin.cs
@@ -5,7 +5,6 @@ using Slipstream.Shared;
 using Slipstream.Shared.Factories;
 using System.Collections.Generic;
 using System.IO;
-using EventHandler = Slipstream.Shared.EventHandler;
 
 #nullable enable
 
@@ -23,13 +22,14 @@ namespace Slipstream.Backend.Plugins
         private readonly string FilePath;
 
         public LuaPlugin(
+            IEventHandlerController eventHandlerController,
             string id,
             ILogger logger,
             IEventFactory eventFactory,
             IEventBus eventBus,
             IServiceLocator serviceLocator,
             Dictionary<dynamic, dynamic> configuration
-        ) : base(id, "LuaPlugin", id, "Lua")
+        ) : base(eventHandlerController, id, "LuaPlugin", id, "Lua")
         {
             Logger = logger;
             LuaEventFactory = eventFactory.Get<ILuaEventFactory>();
@@ -40,8 +40,8 @@ namespace Slipstream.Backend.Plugins
 
             // Avoid that WriteToConsole is evaluated by Lua, that in turn will
             // add more WriteToConsole events, making a endless loop
-            EventHandler.Get<Shared.EventHandlers.UI>().OnUICommandWriteToConsole += (s, e) => { };
-            EventHandler.OnDefault += (s, e) => LuaContext?.HandleEvent(e.Event);
+            EventHandlerController.Get<Shared.EventHandlers.UI>().OnUICommandWriteToConsole += (s, e) => { };
+            EventHandlerController.OnDefault += (s, e) => LuaContext?.HandleEvent(e.Event);
 
             FilePath = configuration["filepath"];
             Prefix = Path.GetFileName(FilePath);

--- a/Backend/Plugins/PlaybackPlugin.cs
+++ b/Backend/Plugins/PlaybackPlugin.cs
@@ -16,11 +16,11 @@ namespace Slipstream.Backend.Plugins
         private readonly IEventBus EventBus;
         private readonly IEventSerdeService EventSerdeService;
 
-        public PlaybackPlugin(string id, ILogger logger, IEventBus eventBus, IServiceLocator serviceLocator) : base(id, "AudioPlugin", id, "Audio", true)
+        public PlaybackPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IEventBus eventBus, IServiceLocator serviceLocator) : base(eventHandlerController, id, "AudioPlugin", id, "Audio", true)
         {
             EventBus = eventBus;
             EventSerdeService = serviceLocator.Get<IEventSerdeService>();
-            var playback = EventHandler.Get<Playback>();
+            var playback = EventHandlerController.Get<Playback>();
 
             playback.OnPlaybackCommandInjectEvents += (s, e) => OnPlaybackCommandInjectEvents(e.Event);
             playback.OnPlaybackCommandSaveEvents += (s, e) => OnPlaybackCommandSaveEvents(e.Event);

--- a/Backend/Plugins/ReceiverPlugin.cs
+++ b/Backend/Plugins/ReceiverPlugin.cs
@@ -36,7 +36,7 @@ namespace Slipstream.Backend.Plugins
                 ;
         }
 
-        public ReceiverPlugin(string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(id, "ReceiverPlugin", id, "ReceiverPlugin", true)
+        public ReceiverPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(eventHandlerController, id, "ReceiverPlugin", id, "ReceiverPlugin", true)
         {
             Logger = logger;
             EventFactory = eventFactory;

--- a/Backend/Plugins/TransmitterPlugin.cs
+++ b/Backend/Plugins/TransmitterPlugin.cs
@@ -8,7 +8,6 @@ using System;
 using System.Diagnostics;
 using System.Net.Sockets;
 using System.Threading;
-using EventHandler = Slipstream.Shared.EventHandler;
 
 #nullable enable
 
@@ -34,7 +33,7 @@ namespace Slipstream.Backend.Plugins
                 ;
         }
 
-        public TransmitterPlugin(string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(id, "TransmitterPlugin", id, "TransmitterPlugin", true)
+        public TransmitterPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(eventHandlerController, id, "TransmitterPlugin", id, "TransmitterPlugin", true)
         {
             Logger = logger;
             EventBus = eventBus;
@@ -46,7 +45,7 @@ namespace Slipstream.Backend.Plugins
             Ip = configuration.Extract<string>("ip");
             Port = (int)configuration.Extract<long>("port");
 
-            EventHandler.OnDefault += (_, e) => OnEvent(e.Event);
+            EventHandlerController.OnDefault += (_, e) => OnEvent(e.Event);
 
             // To avoid that we get an endless loop, we will Unregister the "other" end in this instance
             EventBus.PublishEvent(EventFactory.CreateInternalCommandPluginUnregister("ReceiverPlugin"));

--- a/Backend/Plugins/TwitchPlugin.cs
+++ b/Backend/Plugins/TwitchPlugin.cs
@@ -13,7 +13,6 @@ using TwitchLib.Client.Models;
 using TwitchLib.Communication.Clients;
 using TwitchLib.Communication.Events;
 using TwitchLib.Communication.Models;
-using EventHandler = Slipstream.Shared.EventHandler;
 
 #nullable enable
 
@@ -53,7 +52,7 @@ namespace Slipstream.Backend.Plugins
                 ;
         }
 
-        public TwitchPlugin(string id, ILogger logger, ITwitchEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(id, "TwitchPlugin", id, "TwitchPlugin", true)
+        public TwitchPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, ITwitchEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(eventHandlerController, id, "TwitchPlugin", id, "TwitchPlugin", true)
         {
             Logger = logger;
             EventFactory = eventFactory;
@@ -61,7 +60,7 @@ namespace Slipstream.Backend.Plugins
 
             ConfigurationValidator.Validate(configuration);
 
-            var twitchEventHandler = EventHandler.Get<Shared.EventHandlers.Twitch>();
+            var twitchEventHandler = EventHandlerController.Get<Shared.EventHandlers.Twitch>();
 
             twitchEventHandler.OnTwitchCommandSendMessage += (_, e) => SendMessage(e.Event.Message);
             twitchEventHandler.OnTwitchCommandSendWhisper += (_, e) => SendWhisper(e.Event.To, e.Event.Message);

--- a/Backend/Services/StateService.cs
+++ b/Backend/Services/StateService.cs
@@ -1,5 +1,4 @@
 ﻿using Serilog;
-using Slipstream.Shared;
 using System;
 using System.Collections.Generic;
 using System.IO;
@@ -110,7 +109,7 @@ namespace Slipstream.Backend.Services
                 KeyValues.Remove(key);
             }
 
-            if (value != null && value.Length > 0)
+            if (!string.IsNullOrEmpty(value))
             {
                 if (lifetimSeconds > 0)
                     expiresAt = DateTime.Now.AddSeconds(lifetimSeconds);

--- a/Frontend/MainWindow.cs
+++ b/Frontend/MainWindow.cs
@@ -10,7 +10,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.Threading;
 using System.Windows.Forms;
-using EventHandler = Slipstream.Shared.EventHandler;
+using EventHandler = Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Frontend
 {
@@ -26,12 +26,15 @@ namespace Slipstream.Frontend
         private readonly IDictionary<string, ToolStripMenuItem> MenuPluginItems = new Dictionary<string, ToolStripMenuItem>();
         private readonly IDictionary<string, Button> LuaButtons = new Dictionary<string, Button>();
         private readonly string CleanTitle;
+        private readonly IEventHandlerController EventHandler;
 
-        public MainWindow(IEventFactory eventFactory, IEventBus eventBus, IApplicationVersionService applicationVersionService)
+        public MainWindow(IEventFactory eventFactory, IEventBus eventBus, IApplicationVersionService applicationVersionService, EventHandlerControllerBuilder eventHandlerControllerBuilder)
         {
             InternalEventFactory = eventFactory.Get<IInternalEventFactory>();
             UIEventFactory = eventFactory.Get<IUIEventFactory>();
             PlaybackEventFactory = eventFactory.Get<IPlaybackEventFactory>();
+
+            EventHandler = eventHandlerControllerBuilder.CreateEventHandlerController();
 
             EventBus = eventBus;
 
@@ -102,8 +105,6 @@ namespace Slipstream.Frontend
         }
 
         #region EventHandlerThread methods
-
-        private readonly Shared.EventHandler EventHandler = new Shared.EventHandler();
 
         private void EventListenerMain()
         {

--- a/Program.cs
+++ b/Program.cs
@@ -4,6 +4,7 @@ using System.Windows.Forms;
 using Serilog;
 using Slipstream.Shared;
 using Slipstream.Shared.Factories;
+using System.Diagnostics;
 
 #nullable enable
 
@@ -55,6 +56,7 @@ namespace Slipstream
             services.AddScoped<Backend.Services.IEventSerdeService, Backend.Services.EventSerdeService>();
             services.AddScoped<Backend.IPluginManager, Backend.PluginManager>();
             services.AddScoped<Backend.IPluginFactory, Backend.PluginManager>();
+            services.AddScoped<EventHandlerControllerBuilder>();
             services.AddScoped<IEventFactory, EventFactory>();
             services.AddScoped<Backend.Services.ILuaSevice, Backend.Services.LuaService>();
             services.AddSingleton<Shared.IApplicationVersionService, Shared.ApplicationVersionService>();

--- a/Shared/EventHandlerArgs.cs
+++ b/Shared/EventHandlerArgs.cs
@@ -1,0 +1,16 @@
+﻿#nullable enable
+
+using System;
+
+namespace Slipstream.Shared
+{
+    public class EventHandlerArgs<T> : EventArgs
+    {
+        public T Event { get; }
+
+        public EventHandlerArgs(T e)
+        {
+            Event = e;
+        }
+    }
+}

--- a/Shared/EventHandlerController.cs
+++ b/Shared/EventHandlerController.cs
@@ -1,57 +1,28 @@
 ﻿#nullable enable
 
-using Slipstream.Shared.EventHandlers;
 using System;
 using System.Collections.Generic;
+using static Slipstream.Shared.IEventHandlerController;
 
 namespace Slipstream.Shared
 {
-    internal interface IEventHandler
+    public class EventHandlerController : IEventHandlerController
     {
-        internal enum HandledStatus
-        {
-            NotMine, Handled, UseDefault
-        }
-
-        HandledStatus HandleEvent(IEvent @event);
-    }
-
-    public class EventHandler
-    {
-        public class EventHandlerArgs<T> : EventArgs
-        {
-            public T Event { get; }
-
-            public EventHandlerArgs(T e)
-            {
-                Event = e;
-            }
-        }
-
         internal readonly IDictionary<dynamic, IEventHandler> Handlers = new Dictionary<dynamic, IEventHandler>();
 
         private volatile bool enabled = true;
         public bool Enabled { get { return enabled; } set { enabled = value; } }
-
-        public EventHandler()
-        {
-            Handlers.Add(typeof(Internal), new Internal(this));
-            Handlers.Add(typeof(Lua), new Lua(this));
-            Handlers.Add(typeof(UI), new UI(this));
-            Handlers.Add(typeof(Audio), new Audio(this));
-            Handlers.Add(typeof(IRacing), new IRacing(this));
-            Handlers.Add(typeof(Twitch), new Twitch(this));
-            Handlers.Add(typeof(FileMonitor), new FileMonitor(this));
-            Handlers.Add(typeof(Playback), new Playback(this));
-        }
-
-        public delegate void OnDefaultHandler(EventHandler source, EventHandlerArgs<IEvent> e);
 
         public event OnDefaultHandler? OnDefault;
 
         public T Get<T>()
         {
             return (T)Handlers[typeof(T)];
+        }
+
+        internal void Add(IEventHandler eventHandler)
+        {
+            Handlers.Add(eventHandler.GetType(), eventHandler);
         }
 
         public void HandleEvent(IEvent? ev)

--- a/Shared/EventHandlerControllerBuilder.cs
+++ b/Shared/EventHandlerControllerBuilder.cs
@@ -1,0 +1,25 @@
+﻿#nullable enable
+
+using Slipstream.Shared.EventHandlers;
+
+namespace Slipstream.Shared
+{
+    public class EventHandlerControllerBuilder
+    {
+        public IEventHandlerController CreateEventHandlerController()
+        {
+            var controller = new EventHandlerController();
+
+            controller.Add(new Internal(controller));
+            controller.Add(new Lua(controller));
+            controller.Add(new UI(controller));
+            controller.Add(new Audio(controller));
+            controller.Add(new IRacing(controller));
+            controller.Add(new Twitch(controller));
+            controller.Add(new FileMonitor(controller));
+            controller.Add(new Playback(controller));
+
+            return controller;
+        }
+    }
+}

--- a/Shared/EventHandlers/Audio.cs
+++ b/Shared/EventHandlers/Audio.cs
@@ -1,28 +1,28 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.Audio;
-using static Slipstream.Shared.EventHandler;
+using static Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class Audio : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly EventHandlerController Parent;
 
-        public Audio(EventHandler eventHandler)
+        public Audio(EventHandlerController eventHandler)
         {
             Parent = eventHandler;
         }
 
-        public delegate void OnAudioCommandPlayHandler(EventHandler source, EventHandlerArgs<AudioCommandPlay> e);
+        public delegate void OnAudioCommandPlayHandler(EventHandlerController source, EventHandlerArgs<AudioCommandPlay> e);
 
-        public delegate void OnAudioCommandSayHandler(EventHandler source, EventHandlerArgs<AudioCommandSay> e);
+        public delegate void OnAudioCommandSayHandler(EventHandlerController source, EventHandlerArgs<AudioCommandSay> e);
 
-        public delegate void OnAudioCommandSendDevicesHandler(EventHandler source, EventHandlerArgs<AudioCommandSendDevices> e);
+        public delegate void OnAudioCommandSendDevicesHandler(EventHandlerController source, EventHandlerArgs<AudioCommandSendDevices> e);
 
-        public delegate void OnAudioCommandSetOutputDeviceHandler(EventHandler source, EventHandlerArgs<AudioCommandSetOutputDevice> e);
+        public delegate void OnAudioCommandSetOutputDeviceHandler(EventHandlerController source, EventHandlerArgs<AudioCommandSetOutputDevice> e);
 
-        public delegate void OnAudioOutputDeviceHandler(EventHandler source, EventHandlerArgs<AudioOutputDevice> e);
+        public delegate void OnAudioOutputDeviceHandler(EventHandlerController source, EventHandlerArgs<AudioOutputDevice> e);
 
         public event OnAudioCommandPlayHandler? OnAudioCommandPlay;
 

--- a/Shared/EventHandlers/FileMonitor.cs
+++ b/Shared/EventHandlers/FileMonitor.cs
@@ -1,30 +1,29 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.FileMonitor;
-using static Slipstream.Shared.EventHandler;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class FileMonitor : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly IEventHandlerController Parent;
 
-        public FileMonitor(EventHandler eventHandler)
+        public FileMonitor(IEventHandlerController eventHandler)
         {
             Parent = eventHandler;
         }
 
-        public delegate void OnFileMonitorCommandScanHandler(EventHandler source, EventHandlerArgs<FileMonitorCommandScan> e);
+        public delegate void OnFileMonitorCommandScanHandler(IEventHandlerController source, EventHandlerArgs<FileMonitorCommandScan> e);
 
-        public delegate void OnFileMonitorFileChangedHandler(EventHandler source, EventHandlerArgs<FileMonitorFileChanged> e);
+        public delegate void OnFileMonitorFileChangedHandler(IEventHandlerController source, EventHandlerArgs<FileMonitorFileChanged> e);
 
-        public delegate void OnFileMonitorFileCreatedHandler(EventHandler source, EventHandlerArgs<FileMonitorFileCreated> e);
+        public delegate void OnFileMonitorFileCreatedHandler(IEventHandlerController source, EventHandlerArgs<FileMonitorFileCreated> e);
 
-        public delegate void OnFileMonitorFileDeletedHandler(EventHandler source, EventHandlerArgs<FileMonitorFileDeleted> e);
+        public delegate void OnFileMonitorFileDeletedHandler(IEventHandlerController source, EventHandlerArgs<FileMonitorFileDeleted> e);
 
-        public delegate void OnFileMonitorFileRenamedHandler(EventHandler source, EventHandlerArgs<FileMonitorFileRenamed> e);
+        public delegate void OnFileMonitorFileRenamedHandler(IEventHandlerController source, EventHandlerArgs<FileMonitorFileRenamed> e);
 
-        public delegate void OnFileMonitorScanCompletedHandler(EventHandler source, EventHandlerArgs<FileMonitorScanCompleted> e);
+        public delegate void OnFileMonitorScanCompletedHandler(IEventHandlerController source, EventHandlerArgs<FileMonitorScanCompleted> e);
 
         public event OnFileMonitorCommandScanHandler? OnFileMonitorCommandScan;
 

--- a/Shared/EventHandlers/IRacing.cs
+++ b/Shared/EventHandlers/IRacing.cs
@@ -1,62 +1,62 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.IRacing;
-using static Slipstream.Shared.EventHandler;
+using static Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class IRacing : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly EventHandlerController Parent;
 
-        public IRacing(EventHandler eventHandler)
+        public IRacing(EventHandlerController eventHandler)
         {
             Parent = eventHandler;
         }
 
-        public delegate void OnIRacingCarCompletedLapHandler(EventHandler source, EventHandlerArgs<IRacingCarCompletedLap> e);
+        public delegate void OnIRacingCarCompletedLapHandler(EventHandlerController source, EventHandlerArgs<IRacingCarCompletedLap> e);
 
-        public delegate void OnIRacingCarInfoHandler(EventHandler source, EventHandlerArgs<IRacingCarInfo> e);
+        public delegate void OnIRacingCarInfoHandler(EventHandlerController source, EventHandlerArgs<IRacingCarInfo> e);
 
-        public delegate void OnIRacingCommandSendCarInfoHandler(EventHandler source, EventHandlerArgs<IRacingCommandSendCarInfo> e);
+        public delegate void OnIRacingCommandSendCarInfoHandler(EventHandlerController source, EventHandlerArgs<IRacingCommandSendCarInfo> e);
 
-        public delegate void OnIRacingCommandSendRaceFlagsHandler(EventHandler source, EventHandlerArgs<IRacingCommandSendRaceFlags> e);
+        public delegate void OnIRacingCommandSendRaceFlagsHandler(EventHandlerController source, EventHandlerArgs<IRacingCommandSendRaceFlags> e);
 
-        public delegate void OnIRacingCommandSendSessionStateHandler(EventHandler source, EventHandlerArgs<IRacingCommandSendSessionState> e);
+        public delegate void OnIRacingCommandSendSessionStateHandler(EventHandlerController source, EventHandlerArgs<IRacingCommandSendSessionState> e);
 
-        public delegate void OnIRacingCommandSendTrackInfoHandler(EventHandler source, EventHandlerArgs<IRacingCommandSendTrackInfo> e);
+        public delegate void OnIRacingCommandSendTrackInfoHandler(EventHandlerController source, EventHandlerArgs<IRacingCommandSendTrackInfo> e);
 
-        public delegate void OnIRacingCommandSendWeatherInfoHandler(EventHandler source, EventHandlerArgs<IRacingCommandSendWeatherInfo> e);
+        public delegate void OnIRacingCommandSendWeatherInfoHandler(EventHandlerController source, EventHandlerArgs<IRacingCommandSendWeatherInfo> e);
 
-        public delegate void OnIRacingConnectedHandler(EventHandler source, EventHandlerArgs<IRacingConnected> e);
+        public delegate void OnIRacingConnectedHandler(EventHandlerController source, EventHandlerArgs<IRacingConnected> e);
 
-        public delegate void OnIRacingDisconnectedHandler(EventHandler source, EventHandlerArgs<IRacingDisconnected> e);
+        public delegate void OnIRacingDisconnectedHandler(EventHandlerController source, EventHandlerArgs<IRacingDisconnected> e);
 
-        public delegate void OnIRacingDriverIncidentHandler(EventHandler source, EventHandlerArgs<IRacingDriverIncident> e);
+        public delegate void OnIRacingDriverIncidentHandler(EventHandlerController source, EventHandlerArgs<IRacingDriverIncident> e);
 
-        public delegate void OnIRacingPitEnterHandler(EventHandler source, EventHandlerArgs<IRacingPitEnter> e);
+        public delegate void OnIRacingPitEnterHandler(EventHandlerController source, EventHandlerArgs<IRacingPitEnter> e);
 
-        public delegate void OnIRacingPitExitHandler(EventHandler source, EventHandlerArgs<IRacingPitExit> e);
+        public delegate void OnIRacingPitExitHandler(EventHandlerController source, EventHandlerArgs<IRacingPitExit> e);
 
-        public delegate void OnIRacingPitstopReportHandler(EventHandler source, EventHandlerArgs<IRacingPitstopReport> e);
+        public delegate void OnIRacingPitstopReportHandler(EventHandlerController source, EventHandlerArgs<IRacingPitstopReport> e);
 
-        public delegate void OnIRacingRaceFlagsHandler(EventHandler source, EventHandlerArgs<IRacingRaceFlags> e);
+        public delegate void OnIRacingRaceFlagsHandler(EventHandlerController source, EventHandlerArgs<IRacingRaceFlags> e);
 
-        public delegate void OnIRacingTrackInfoHandler(EventHandler source, EventHandlerArgs<IRacingTrackInfo> e);
+        public delegate void OnIRacingTrackInfoHandler(EventHandlerController source, EventHandlerArgs<IRacingTrackInfo> e);
 
-        public delegate void OnIRacingWeatherInfoHandler(EventHandler source, EventHandlerArgs<IRacingWeatherInfo> e);
+        public delegate void OnIRacingWeatherInfoHandler(EventHandlerController source, EventHandlerArgs<IRacingWeatherInfo> e);
 
-        public delegate void OnIRacingPracticeHandler(EventHandler source, EventHandlerArgs<IRacingPractice> e);
+        public delegate void OnIRacingPracticeHandler(EventHandlerController source, EventHandlerArgs<IRacingPractice> e);
 
-        public delegate void OnIRacingQualifyHandler(EventHandler source, EventHandlerArgs<IRacingQualify> e);
+        public delegate void OnIRacingQualifyHandler(EventHandlerController source, EventHandlerArgs<IRacingQualify> e);
 
-        public delegate void OnIRacingRaceHandler(EventHandler source, EventHandlerArgs<IRacingRace> e);
+        public delegate void OnIRacingRaceHandler(EventHandlerController source, EventHandlerArgs<IRacingRace> e);
 
-        public delegate void OnIRacingTestingHandler(EventHandler source, EventHandlerArgs<IRacingTesting> e);
+        public delegate void OnIRacingTestingHandler(EventHandlerController source, EventHandlerArgs<IRacingTesting> e);
 
-        public delegate void OnIRacingWarmupHandler(EventHandler source, EventHandlerArgs<IRacingWarmup> e);
+        public delegate void OnIRacingWarmupHandler(EventHandlerController source, EventHandlerArgs<IRacingWarmup> e);
 
-        public delegate void OnIRacingCarPositionHandler(EventHandler source, EventHandlerArgs<IRacingCarPosition> e);
+        public delegate void OnIRacingCarPositionHandler(EventHandlerController source, EventHandlerArgs<IRacingCarPosition> e);
 
         public event OnIRacingCarCompletedLapHandler? OnIRacingCarCompletedLap;
 
@@ -99,6 +99,7 @@ namespace Slipstream.Shared.EventHandlers
         public event OnIRacingTestingHandler? OnIRacingTesting;
 
         public event OnIRacingWarmupHandler? OnIRacingWarmup;
+
         public event OnIRacingCarPositionHandler? OnIRacingCarPosition;
 
         public IEventHandler.HandledStatus HandleEvent(IEvent @event)

--- a/Shared/EventHandlers/Internal.cs
+++ b/Shared/EventHandlers/Internal.cs
@@ -1,26 +1,25 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.Internal;
-using static Slipstream.Shared.EventHandler;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class Internal : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly IEventHandlerController Parent;
 
-        public Internal(EventHandler parent)
+        public Internal(IEventHandlerController parent)
         {
             Parent = parent;
         }
 
-        public delegate void OnInternalCommandPluginRegisterHandler(EventHandler source, EventHandlerArgs<InternalCommandPluginRegister> e);
+        public delegate void OnInternalCommandPluginRegisterHandler(IEventHandlerController source, EventHandlerArgs<InternalCommandPluginRegister> e);
 
-        public delegate void OnInternalCommandPluginStatesHandler(EventHandler source, EventHandlerArgs<InternalCommandPluginStates> e);
+        public delegate void OnInternalCommandPluginStatesHandler(IEventHandlerController source, EventHandlerArgs<InternalCommandPluginStates> e);
 
-        public delegate void OnInternalCommandPluginUnregisterHandler(EventHandler source, EventHandlerArgs<InternalCommandPluginUnregister> e);
+        public delegate void OnInternalCommandPluginUnregisterHandler(IEventHandlerController source, EventHandlerArgs<InternalCommandPluginUnregister> e);
 
-        public delegate void OnInternalPluginStateHandler(EventHandler source, EventHandlerArgs<InternalPluginState> e);
+        public delegate void OnInternalPluginStateHandler(IEventHandlerController source, EventHandlerArgs<InternalPluginState> e);
 
         public event OnInternalCommandPluginRegisterHandler? OnInternalCommandPluginRegister;
 

--- a/Shared/EventHandlers/Lua.cs
+++ b/Shared/EventHandlers/Lua.cs
@@ -1,20 +1,20 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.Lua;
-using static Slipstream.Shared.EventHandler;
+using static Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class Lua : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly EventHandlerController Parent;
 
-        public Lua(EventHandler parent)
+        public Lua(EventHandlerController parent)
         {
             Parent = parent;
         }
 
-        public delegate void OnLuaDeduplicateEventsHandler(EventHandler source, EventHandlerArgs<LuaCommandDeduplicateEvents> e);
+        public delegate void OnLuaDeduplicateEventsHandler(EventHandlerController source, EventHandlerArgs<LuaCommandDeduplicateEvents> e);
 
         public event OnLuaDeduplicateEventsHandler? OnLuaCommandDeduplicateEvents;
 

--- a/Shared/EventHandlers/Playback.cs
+++ b/Shared/EventHandlers/Playback.cs
@@ -1,22 +1,22 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.Playback;
-using static Slipstream.Shared.EventHandler;
+using static Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class Playback : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly EventHandlerController Parent;
 
-        public Playback(EventHandler parent)
+        public Playback(EventHandlerController parent)
         {
             Parent = parent;
         }
 
-        public delegate void OnPlaybackCommandInjectEventsHandler(EventHandler source, EventHandlerArgs<PlaybackCommandInjectEvents> e);
+        public delegate void OnPlaybackCommandInjectEventsHandler(EventHandlerController source, EventHandlerArgs<PlaybackCommandInjectEvents> e);
         public event OnPlaybackCommandInjectEventsHandler? OnPlaybackCommandInjectEvents;
-        public delegate void OnPlaybackCommandSaveEventsHandler(EventHandler source, EventHandlerArgs<PlaybackCommandSaveEvents> e);
+        public delegate void OnPlaybackCommandSaveEventsHandler(EventHandlerController source, EventHandlerArgs<PlaybackCommandSaveEvents> e);
         public event OnPlaybackCommandSaveEventsHandler? OnPlaybackCommandSaveEvents;
 
         public IEventHandler.HandledStatus HandleEvent(IEvent @event)

--- a/Shared/EventHandlers/Twitch.cs
+++ b/Shared/EventHandlers/Twitch.cs
@@ -1,36 +1,36 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.Twitch;
-using static Slipstream.Shared.EventHandler;
+using static Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class Twitch : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly EventHandlerController Parent;
 
-        public Twitch(EventHandler eventHandler)
+        public Twitch(EventHandlerController eventHandler)
         {
             Parent = eventHandler;
         }
 
-        public delegate void OnTwitchCommandSendMessageHandler(EventHandler source, EventHandlerArgs<TwitchCommandSendMessage> e);
+        public delegate void OnTwitchCommandSendMessageHandler(EventHandlerController source, EventHandlerArgs<TwitchCommandSendMessage> e);
 
-        public delegate void OnTwitchCommandSendWhisperHandler(EventHandler source, EventHandlerArgs<TwitchCommandSendWhisper> e);
+        public delegate void OnTwitchCommandSendWhisperHandler(EventHandlerController source, EventHandlerArgs<TwitchCommandSendWhisper> e);
 
-        public delegate void OnTwitchConnectedHandler(EventHandler source, EventHandlerArgs<TwitchConnected> e);
+        public delegate void OnTwitchConnectedHandler(EventHandlerController source, EventHandlerArgs<TwitchConnected> e);
 
-        public delegate void OnTwitchDisconnectedHandler(EventHandler source, EventHandlerArgs<TwitchDisconnected> e);
+        public delegate void OnTwitchDisconnectedHandler(EventHandlerController source, EventHandlerArgs<TwitchDisconnected> e);
 
-        public delegate void OnTwitchReceivedMessageHandler(EventHandler source, EventHandlerArgs<TwitchReceivedMessage> e);
+        public delegate void OnTwitchReceivedMessageHandler(EventHandlerController source, EventHandlerArgs<TwitchReceivedMessage> e);
 
-        public delegate void OnTwitchReceivedWhisperHandler(EventHandler source, EventHandlerArgs<TwitchReceivedWhisper> e);
+        public delegate void OnTwitchReceivedWhisperHandler(EventHandlerController source, EventHandlerArgs<TwitchReceivedWhisper> e);
 
-        public delegate void OnTwitchUserSubscribedHandler(EventHandler source, EventHandlerArgs<TwitchUserSubscribed> e);
+        public delegate void OnTwitchUserSubscribedHandler(EventHandlerController source, EventHandlerArgs<TwitchUserSubscribed> e);
 
-        public delegate void OnTwitchGiftedSubscriptionHandler(EventHandler source, EventHandlerArgs<TwitchGiftedSubscription> e);
+        public delegate void OnTwitchGiftedSubscriptionHandler(EventHandlerController source, EventHandlerArgs<TwitchGiftedSubscription> e);
 
-        public delegate void OnTwitchRaidedHandler(EventHandler source, EventHandlerArgs<TwitchRaided> e);
+        public delegate void OnTwitchRaidedHandler(EventHandlerController source, EventHandlerArgs<TwitchRaided> e);
 
         public event OnTwitchCommandSendMessageHandler? OnTwitchCommandSendMessage;
 

--- a/Shared/EventHandlers/UI.cs
+++ b/Shared/EventHandlers/UI.cs
@@ -1,26 +1,26 @@
 ﻿#nullable enable
 
 using Slipstream.Shared.Events.UI;
-using static Slipstream.Shared.EventHandler;
+using static Slipstream.Shared.EventHandlerController;
 
 namespace Slipstream.Shared.EventHandlers
 {
     internal class UI : IEventHandler
     {
-        private readonly EventHandler Parent;
+        private readonly EventHandlerController Parent;
 
-        public UI(EventHandler eventHandler)
+        public UI(EventHandlerController eventHandler)
         {
             Parent = eventHandler;
         }
 
-        public delegate void OnUIButtonTriggeredHandler(EventHandler source, EventHandlerArgs<UIButtonTriggered> e);
+        public delegate void OnUIButtonTriggeredHandler(EventHandlerController source, EventHandlerArgs<UIButtonTriggered> e);
 
-        public delegate void OnUICommandCreateButtonHandler(EventHandler source, EventHandlerArgs<UICommandCreateButton> e);
+        public delegate void OnUICommandCreateButtonHandler(EventHandlerController source, EventHandlerArgs<UICommandCreateButton> e);
 
-        public delegate void OnUICommandDeleteButtonHandler(EventHandler source, EventHandlerArgs<UICommandDeleteButton> e);
+        public delegate void OnUICommandDeleteButtonHandler(EventHandlerController source, EventHandlerArgs<UICommandDeleteButton> e);
 
-        public delegate void OnUICommandWriteToConsoleHandler(EventHandler source, EventHandlerArgs<UICommandWriteToConsole> e);
+        public delegate void OnUICommandWriteToConsoleHandler(EventHandlerController source, EventHandlerArgs<UICommandWriteToConsole> e);
 
         public event OnUIButtonTriggeredHandler? OnUIButtonTriggered;
 

--- a/Shared/IEventHandler.cs
+++ b/Shared/IEventHandler.cs
@@ -1,0 +1,15 @@
+﻿#nullable enable
+
+
+namespace Slipstream.Shared
+{
+    internal interface IEventHandler
+    {
+        internal enum HandledStatus
+        {
+            NotMine, Handled, UseDefault
+        }
+
+        HandledStatus HandleEvent(IEvent @event);
+    }
+}

--- a/Shared/IEventHandlerController.cs
+++ b/Shared/IEventHandlerController.cs
@@ -1,0 +1,17 @@
+﻿#nullable enable
+
+namespace Slipstream.Shared
+{
+    public interface IEventHandlerController
+    {
+        public bool Enabled { get; set; }
+
+        public delegate void OnDefaultHandler(IEventHandlerController source, EventHandlerArgs<IEvent> e);
+
+        public event OnDefaultHandler? OnDefault;
+
+        public T Get<T>();
+
+        public void HandleEvent(IEvent? ev);
+    }
+}

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -154,6 +154,8 @@
     <Compile Include="Backend\Services\ITxrxService.cs" />
     <Compile Include="Backend\Services\LuaService.cs" />
     <Compile Include="Backend\Services\ILuaContext.cs" />
+    <Compile Include="Shared\EventHandlerArgs.cs" />
+    <Compile Include="Shared\EventHandlerControllerBuilder.cs" />
     <Compile Include="Shared\Events\IRacing\IIRacingSessionState.cs" />
     <Compile Include="Shared\Events\IRacing\IRacingCarPosition.cs" />
     <Compile Include="Shared\Events\IRacing\IRacingWarmup.cs" />
@@ -242,7 +244,7 @@
     <Compile Include="Backend\Plugins\FileMonitorPlugin.cs" />
     <Compile Include="Shared\Events\IRacing\IRacingTrackInfo.cs" />
     <Compile Include="Backend\PluginWorker.cs" />
-    <Compile Include="Shared\EventHandler.cs" />
+    <Compile Include="Shared\EventHandlerController.cs" />
     <Compile Include="Shared\Events\FileMonitor\FileMonitorFileChanged.cs" />
     <Compile Include="Shared\Events\FileMonitor\FileMonitorFileDeleted.cs" />
     <Compile Include="Shared\Events\FileMonitor\FileMonitorFileRenamed.cs" />
@@ -265,6 +267,8 @@
     <Compile Include="Backend\IPlugin.cs" />
     <Compile Include="Shared\IEvent.cs" />
     <Compile Include="Shared\IEventFactory.cs" />
+    <Compile Include="Shared\IEventHandler.cs" />
+    <Compile Include="Shared\IEventHandlerController.cs" />
     <Compile Include="Shared\IEventProducer.cs" />
     <Compile Include="Backend\Worker.cs" />
     <Compile Include="Frontend\MainWindow.cs">


### PR DESCRIPTION
There were some confusing naming. For starter, the IEventHandler and
EventHandler wasn't related.

So this commit introduces renames EventHandler to EventHandlerController
(as this is the "parent" of the EventHandlers, whom implements the
IEventHandler).

EventHandlerControllers are also created by a
EventHandlerControllerBuilder and not ad-hoc as needed.
