### PR TITLE
Simplify plugin threads

### DIFF
--- a/Backend/EventBusSubscription.cs
+++ b/Backend/EventBusSubscription.cs
@@ -5,7 +5,7 @@ using System.Collections.Concurrent;
 
 namespace Slipstream.Backend
 {
-    class EventBusSubscription : IEventBusSubscription
+    internal class EventBusSubscription : IEventBusSubscription
     {
         private readonly BlockingCollection<IEvent> Events = new BlockingCollection<IEvent>();
         private readonly IEventBus EventBus;

--- a/Backend/IPlugin.cs
+++ b/Backend/IPlugin.cs
@@ -24,7 +24,6 @@ namespace Slipstream.Backend
         public string Id { get; }
         public string Name { get; }
         public string DisplayName { get; }
-        public string WorkerName { get; }
         public IEventHandlerController EventHandlerController { get; }
         public bool Reconfigurable { get; }
 

--- a/Backend/Plugins/AudioPlugin.cs
+++ b/Backend/Plugins/AudioPlugin.cs
@@ -32,7 +32,7 @@ namespace Slipstream.Backend.Plugins
                 .PermitLong("output");
         }
 
-        public AudioPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IEventBus eventBus, IAudioEventFactory eventFactory, Parameters configuration) : base(eventHandlerController, id, "AudioPlugin", id, id, true)
+        public AudioPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IEventBus eventBus, IAudioEventFactory eventFactory, Parameters configuration) : base(eventHandlerController, id, "AudioPlugin", id, true)
         {
             Logger = logger;
             EventBus = eventBus;

--- a/Backend/Plugins/BasePlugin.cs
+++ b/Backend/Plugins/BasePlugin.cs
@@ -23,27 +23,18 @@ namespace Slipstream.Backend.Plugins
             set { displayName = value; OnStateChanged?.Invoke(this, new IPlugin.EventHandlerArgs<IPlugin>(this)); }
         }
 
-        private string workerName = "INVALID-WORKER-NAME";
-
         public event IPlugin.OnStateChangedHandler? OnStateChanged;
 
         public bool Reconfigurable { get; }
 
-        public string WorkerName
-        {
-            get { return workerName; }
-            set { workerName = value; OnStateChanged?.Invoke(this, new IPlugin.EventHandlerArgs<IPlugin>(this)); }
-        }
-
         public IEventHandlerController EventHandlerController { get; }
 
-        public BasePlugin(IEventHandlerController eventHandlerController, string id, string name, string displayName, string workerName, bool reconfigurable = false)
+        public BasePlugin(IEventHandlerController eventHandlerController, string id, string name, string displayName, bool reconfigurable = false)
         {
             EventHandlerController = eventHandlerController;
             Id = id;
             Name = name;
             DisplayName = displayName;
-            WorkerName = workerName;
             Reconfigurable = reconfigurable;
         }
 

--- a/Backend/Plugins/FileMonitorPlugin.cs
+++ b/Backend/Plugins/FileMonitorPlugin.cs
@@ -24,7 +24,7 @@ namespace Slipstream.Backend.Plugins
                 .PermitArray("paths", (a) => a.RequireString());
         }
 
-        public FileMonitorPlugin(IEventHandlerController eventHandlerController, string id, IFileMonitorEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(eventHandlerController, id, "FileMonitorPlugin", id, "Core", true)
+        public FileMonitorPlugin(IEventHandlerController eventHandlerController, string id, IFileMonitorEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(eventHandlerController, id, "FileMonitorPlugin", id, true)
         {
             EventFactory = eventFactory;
             EventBus = eventBus;

--- a/Backend/Plugins/IRacingPlugin.cs
+++ b/Backend/Plugins/IRacingPlugin.cs
@@ -100,7 +100,7 @@ namespace Slipstream.Backend.Plugins
         private bool SendSessionState = false;
         private bool SendRaceFlags = false;
 
-        public IRacingPlugin(IEventHandlerController eventHandlerController, string id, IIRacingEventFactory eventFactory, IEventBus eventBus) : base(eventHandlerController, id, "IRacingPlugin", id, "IRacingPlugin")
+        public IRacingPlugin(IEventHandlerController eventHandlerController, string id, IIRacingEventFactory eventFactory, IEventBus eventBus) : base(eventHandlerController, id, "IRacingPlugin", id)
         {
             EventFactory = eventFactory;
             EventBus = eventBus;

--- a/Backend/Plugins/LuaManagerPlugin.cs
+++ b/Backend/Plugins/LuaManagerPlugin.cs
@@ -33,7 +33,7 @@ namespace Slipstream.Backend.Plugins
         private DateTime? BootupEventsDeadline;
         private readonly List<IEvent> CapturedBootupEvents = new List<IEvent>();
 
-        public LuaManagerPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IFileMonitorEventFactory eventFactory, IEventBus eventBus, IPluginManager pluginManager, IPluginFactory pluginFactory, IServiceLocator serviceLocator) : base(eventHandlerController, id, "LuaManagerPlugin", id, "Core")
+        public LuaManagerPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IFileMonitorEventFactory eventFactory, IEventBus eventBus, IPluginManager pluginManager, IPluginFactory pluginFactory, IServiceLocator serviceLocator) : base(eventHandlerController, id, "LuaManagerPlugin", id)
         {
             Logger = logger;
             EventFactory = eventFactory;

--- a/Backend/Plugins/LuaPlugin.cs
+++ b/Backend/Plugins/LuaPlugin.cs
@@ -29,7 +29,7 @@ namespace Slipstream.Backend.Plugins
             IEventBus eventBus,
             IServiceLocator serviceLocator,
             Dictionary<dynamic, dynamic> configuration
-        ) : base(eventHandlerController, id, "LuaPlugin", id, "Lua")
+        ) : base(eventHandlerController, id, "LuaPlugin", id)
         {
             Logger = logger;
             LuaEventFactory = eventFactory.Get<ILuaEventFactory>();

--- a/Backend/Plugins/PlaybackPlugin.cs
+++ b/Backend/Plugins/PlaybackPlugin.cs
@@ -16,7 +16,7 @@ namespace Slipstream.Backend.Plugins
         private readonly IEventBus EventBus;
         private readonly IEventSerdeService EventSerdeService;
 
-        public PlaybackPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IEventBus eventBus, IServiceLocator serviceLocator) : base(eventHandlerController, id, "AudioPlugin", id, "Audio", true)
+        public PlaybackPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IEventBus eventBus, IServiceLocator serviceLocator) : base(eventHandlerController, id, "PlaybackPlugin", id, true)
         {
             EventBus = eventBus;
             EventSerdeService = serviceLocator.Get<IEventSerdeService>();

--- a/Backend/Plugins/ReceiverPlugin.cs
+++ b/Backend/Plugins/ReceiverPlugin.cs
@@ -36,7 +36,7 @@ namespace Slipstream.Backend.Plugins
                 ;
         }
 
-        public ReceiverPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(eventHandlerController, id, "ReceiverPlugin", id, "ReceiverPlugin", true)
+        public ReceiverPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(eventHandlerController, id, "ReceiverPlugin", id, true)
         {
             Logger = logger;
             EventFactory = eventFactory;

--- a/Backend/Plugins/TransmitterPlugin.cs
+++ b/Backend/Plugins/TransmitterPlugin.cs
@@ -33,7 +33,7 @@ namespace Slipstream.Backend.Plugins
                 ;
         }
 
-        public TransmitterPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(eventHandlerController, id, "TransmitterPlugin", id, "TransmitterPlugin", true)
+        public TransmitterPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, IInternalEventFactory eventFactory, IEventBus eventBus, IServiceLocator serviceLocator, Parameters configuration) : base(eventHandlerController, id, "TransmitterPlugin", id, true)
         {
             Logger = logger;
             EventBus = eventBus;

--- a/Backend/Plugins/TwitchPlugin.cs
+++ b/Backend/Plugins/TwitchPlugin.cs
@@ -52,7 +52,7 @@ namespace Slipstream.Backend.Plugins
                 ;
         }
 
-        public TwitchPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, ITwitchEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(eventHandlerController, id, "TwitchPlugin", id, "TwitchPlugin", true)
+        public TwitchPlugin(IEventHandlerController eventHandlerController, string id, ILogger logger, ITwitchEventFactory eventFactory, IEventBus eventBus, Parameters configuration) : base(eventHandlerController, id, "TwitchPlugin", id, true)
         {
             Logger = logger;
             EventFactory = eventFactory;

--- a/Backend/Worker.cs
+++ b/Backend/Worker.cs
@@ -3,13 +3,14 @@ using System.Threading;
 
 namespace Slipstream.Backend
 {
-    abstract class Worker : IDisposable
+    internal abstract class Worker : IDisposable
     {
         public string Name { get; }
         private readonly Thread WorkerThread;
         private readonly object StopLock = new object();
         private bool stop;
         private bool started;
+
         protected bool Stopped
         {
             get

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -141,10 +141,10 @@
     <Compile Include="Backend\IPluginFactory.cs" />
     <Compile Include="Backend\IPluginManager.cs" />
     <Compile Include="Backend\PluginManager.cs" />
+    <Compile Include="Backend\Plugins\AudioPlugin.cs" />
     <Compile Include="Backend\Plugins\PlaybackPlugin.cs" />
     <Compile Include="Backend\Plugins\ReceiverPlugin.cs" />
     <Compile Include="Backend\Plugins\TransmitterPlugin.cs" />
-    <Compile Include="Backend\Plugins\AudioPlugin.cs" />
     <Compile Include="Backend\Plugins\BasePlugin.cs" />
     <Compile Include="Backend\Plugins\TwitchPlugin.cs" />
     <Compile Include="Backend\Services\IEventSerdeService.cs" />
@@ -154,8 +154,15 @@
     <Compile Include="Backend\Services\ITxrxService.cs" />
     <Compile Include="Backend\Services\LuaService.cs" />
     <Compile Include="Backend\Services\ILuaContext.cs" />
+    <Compile Include="Backend\Services\LuaServiceLib\AudioMethodCollection.cs" />
     <Compile Include="Shared\EventHandlerArgs.cs" />
     <Compile Include="Shared\EventHandlerControllerBuilder.cs" />
+    <Compile Include="Shared\EventHandlers\Audio.cs" />
+    <Compile Include="Shared\Events\Audio\AudioCommandPlay.cs" />
+    <Compile Include="Shared\Events\Audio\AudioCommandSay.cs" />
+    <Compile Include="Shared\Events\Audio\AudioCommandSendDevices.cs" />
+    <Compile Include="Shared\Events\Audio\AudioCommandSetOutputDevice.cs" />
+    <Compile Include="Shared\Events\Audio\AudioOutputDevice.cs" />
     <Compile Include="Shared\Events\IRacing\IIRacingSessionState.cs" />
     <Compile Include="Shared\Events\IRacing\IRacingCarPosition.cs" />
     <Compile Include="Shared\Events\IRacing\IRacingWarmup.cs" />
@@ -166,6 +173,8 @@
     <Compile Include="Shared\Events\Twitch\TwitchRaided.cs" />
     <Compile Include="Shared\Events\Twitch\TwitchGiftedSubscription.cs" />
     <Compile Include="Shared\Events\Twitch\TwitchUserSubscribed.cs" />
+    <Compile Include="Shared\Factories\AudioEventFactory.cs" />
+    <Compile Include="Shared\Factories\IAudioEventFactory.cs" />
     <Compile Include="Shared\Helpers\StrongParameters\Validators\ArrayValidator.cs" />
     <Compile Include="Shared\Helpers\StrongParameters\Validators\BooleanValidator.cs" />
     <Compile Include="Shared\Helpers\StrongParameters\Validators\FloatValidator.cs" />
@@ -175,7 +184,6 @@
     <Compile Include="Shared\Helpers\StrongParameters\Validators\DictionaryValidator.cs" />
     <Compile Include="Shared\Helpers\StrongParameters\Parameters.cs" />
     <Compile Include="Backend\Services\LuaServiceLib\PlaybackMethodCollection.cs" />
-    <Compile Include="Backend\Services\LuaServiceLib\AudioMethodCollection.cs" />
     <Compile Include="Backend\Services\LuaServiceLib\CoreMethodCollection.cs" />
     <Compile Include="Backend\Services\LuaServiceLib\IRacingMethodCollection.cs" />
     <Compile Include="Backend\Services\LuaServiceLib\HttpMethodCollection.cs" />
@@ -190,14 +198,9 @@
     <Compile Include="Backend\Services\TxrxService.cs" />
     <Compile Include="GlobalSuppressions2.cs" />
     <Compile Include="Shared\EventFactory.cs" />
-    <Compile Include="Shared\EventHandlers\Audio.cs" />
     <Compile Include="Shared\EventHandlers\Playback.cs" />
     <Compile Include="Shared\Events\Playback\PlaybackCommandInjectEvents.cs" />
     <Compile Include="Shared\Events\Playback\PlaybackCommandSaveEvents.cs" />
-    <Compile Include="Shared\Events\Audio\AudioCommandSetOutputDevice.cs" />
-    <Compile Include="Shared\Events\Audio\AudioCommandSendDevices.cs" />
-    <Compile Include="Shared\Events\Audio\AudioOutputDevice.cs" />
-    <Compile Include="Shared\Factories\AudioEventFactory.cs" />
     <Compile Include="Shared\Factories\IInternalEventFactory.cs" />
     <Compile Include="Shared\Factories\IPlaybackEventFactory.cs" />
     <Compile Include="Shared\Factories\PlaybackEventFactory.cs" />
@@ -219,7 +222,6 @@
     <Compile Include="Shared\Events\UI\UICommandDeleteButton.cs" />
     <Compile Include="Shared\Events\UI\UICommandCreateButton.cs" />
     <Compile Include="Shared\Factories\FileMonitorEventFactory.cs" />
-    <Compile Include="Shared\Factories\IAudioEventFactory.cs" />
     <Compile Include="Shared\Factories\IFileMonitorEventFactory.cs" />
     <Compile Include="Shared\Factories\IIRacingEventFactory.cs" />
     <Compile Include="Shared\Factories\ILuaEventFactory.cs" />
@@ -256,8 +258,6 @@
     <Compile Include="Shared\Events\Twitch\TwitchCommandSendMessage.cs" />
     <Compile Include="Shared\Events\Twitch\TwitchDisconnected.cs" />
     <Compile Include="Shared\Events\Twitch\TwitchConnected.cs" />
-    <Compile Include="Shared\Events\Audio\AudioCommandPlay.cs" />
-    <Compile Include="Shared\Events\Audio\AudioCommandSay.cs" />
     <Compile Include="Shared\Events\UI\UICommandWriteToConsole.cs" />
     <Compile Include="Shared\IApplicationVersionService.cs" />
     <Compile Include="Shared\IEventBus.cs" />


### PR DESCRIPTION
Instead of having a PluginWorker that runs 1 or more plugins, then
just have one plugin per PluginWorker. This will give overhead in
terms of some plugins doesn't do much, but it simplifies code and
Lua scripts doesn't need to share same thread
