### PR TITLE
IRacing: Adds event for realtime position tracking

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Next version
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.4.1...main)
+  - Event: Adds IRacingTrackPosition
 
 ## [0.4.1](https://github.com/dennis/slipstream/releases/tag/v0.4.1) (2021-03-20)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.4.0...v0.4.1)

--- a/Components/IRacing/EventFactory/IRacingEventFactory.cs
+++ b/Components/IRacing/EventFactory/IRacingEventFactory.cs
@@ -1,6 +1,5 @@
 ﻿using Slipstream.Components.IRacing.Events;
 using Slipstream.Components.IRacing.Plugins.GameState;
-using Slipstream.Shared;
 using System;
 using static Slipstream.Components.IRacing.IIRacingEventFactory;
 
@@ -433,12 +432,28 @@ namespace Slipstream.Components.IRacing.EventFactory
             };
         }
 
-        public IEvent CreateIRacingTowed(double sessionTime, float remainingTowTime)
+        public IRacingTowed CreateIRacingTowed(double sessionTime, float remainingTowTime)
         {
             return new IRacingTowed
             {
                 SessionTime = sessionTime,
                 RemainingTowTime = remainingTowTime,
+            };
+        }
+
+        public IRacingTrackPosition CreateIRacingTrackPosition(double sessionTime, long carIdx, bool localUser, int currentPositionInRace, int currentPositionInClass, int previousPositionInRace, int previousPositionInClass, int[] newCarsAhead, int[] newCarsBehind)
+        {
+            return new IRacingTrackPosition
+            {
+                SessionTime = sessionTime,
+                CarIdx = carIdx,
+                LocalUser = localUser,
+                CurrentPositionInRace = currentPositionInRace,
+                CurrentPositionInClass = currentPositionInClass,
+                PreviousPositionInRace = previousPositionInRace,
+                PreviousPositionInClass = previousPositionInClass,
+                NewCarsAhead = newCarsAhead,
+                NewCarsBehind = newCarsBehind,
             };
         }
     }

--- a/Components/IRacing/EventHandler/IRacing.cs
+++ b/Components/IRacing/EventHandler/IRacing.cs
@@ -62,6 +62,8 @@ namespace Slipstream.Components.IRacing.EventHandler
 
         public delegate void OnIRacingTowedHandler(EventHandlerController source, EventHandlerArgs<IRacingTowed> e);
 
+        public delegate void OnIRacingTrackPositionHandler(EventHandlerController source, EventHandlerArgs<IRacingTrackPosition> e);
+
         public event OnIRacingCarCompletedLapHandler? OnIRacingCarCompletedLap;
 
         public event OnIRacingCarInfoHandler? OnIRacingCarInfo;
@@ -109,6 +111,8 @@ namespace Slipstream.Components.IRacing.EventHandler
         public event OnIRacingRawHandler? OnIRacingRaw;
 
         public event OnIRacingTowedHandler? OnIRacingTowed;
+
+        public event OnIRacingTrackPositionHandler? OnIRacingTrackPosition;
 
         public IEventHandler.HandledStatus HandleEvent(IEvent @event)
         {
@@ -348,6 +352,17 @@ namespace Slipstream.Components.IRacing.EventHandler
                     if (OnIRacingTowed != null)
                     {
                         OnIRacingTowed(Parent, new EventHandlerArgs<IRacingTowed>(tev));
+                        return IEventHandler.HandledStatus.Handled;
+                    }
+                    else
+                    {
+                        return IEventHandler.HandledStatus.UseDefault;
+                    }
+
+                case IRacingTrackPosition tev:
+                    if (OnIRacingTrackPosition != null)
+                    {
+                        OnIRacingTrackPosition(Parent, new EventHandlerArgs<IRacingTrackPosition>(tev));
                         return IEventHandler.HandledStatus.Handled;
                     }
                     else

--- a/Components/IRacing/Events/IRacingTrackPosition.cs
+++ b/Components/IRacing/Events/IRacingTrackPosition.cs
@@ -1,0 +1,56 @@
+﻿#nullable enable
+
+using Slipstream.Shared;
+using System.Collections.Generic;
+
+namespace Slipstream.Components.IRacing.Events
+{
+    public class IRacingTrackPosition : IEvent
+    {
+        public string EventType => "IRacingTrackPosition";
+        public bool ExcludeFromTxrx => false;
+        public ulong Uptime { get; set; }
+        public double SessionTime { get; set; }
+        public long CarIdx { get; set; }
+        public bool LocalUser { get; set; }
+        public int CurrentPositionInClass { get; set; }
+        public int CurrentPositionInRace { get; set; }
+        public int PreviousPositionInClass { get; set; }
+        public int PreviousPositionInRace { get; set; }
+        public int[] NewCarsAhead { get; set; } = new int[] { };
+        public int[] NewCarsBehind { get; set; } = new int[] { };
+
+        public override bool Equals(object? obj)
+        {
+            return obj is IRacingTrackPosition position &&
+                   EventType == position.EventType &&
+                   ExcludeFromTxrx == position.ExcludeFromTxrx &&
+                   SessionTime == position.SessionTime &&
+                   CarIdx == position.CarIdx &&
+                   LocalUser == position.LocalUser &&
+                   CurrentPositionInClass == position.CurrentPositionInClass &&
+                   CurrentPositionInRace == position.CurrentPositionInRace &&
+                   PreviousPositionInClass == position.PreviousPositionInClass &&
+                   PreviousPositionInRace == position.PreviousPositionInRace &&
+                   EqualityComparer<int[]>.Default.Equals(NewCarsAhead, position.NewCarsAhead) &&
+                   EqualityComparer<int[]>.Default.Equals(NewCarsBehind, position.NewCarsBehind);
+        }
+
+        public override int GetHashCode()
+        {
+            int hashCode = -317246058;
+            hashCode = hashCode * -1521134295 + EqualityComparer<string>.Default.GetHashCode(EventType);
+            hashCode = hashCode * -1521134295 + ExcludeFromTxrx.GetHashCode();
+            hashCode = hashCode * -1521134295 + SessionTime.GetHashCode();
+            hashCode = hashCode * -1521134295 + CarIdx.GetHashCode();
+            hashCode = hashCode * -1521134295 + LocalUser.GetHashCode();
+            hashCode = hashCode * -1521134295 + CurrentPositionInClass.GetHashCode();
+            hashCode = hashCode * -1521134295 + CurrentPositionInRace.GetHashCode();
+            hashCode = hashCode * -1521134295 + PreviousPositionInClass.GetHashCode();
+            hashCode = hashCode * -1521134295 + PreviousPositionInRace.GetHashCode();
+            hashCode = hashCode * -1521134295 + EqualityComparer<int[]>.Default.GetHashCode(NewCarsAhead);
+            hashCode = hashCode * -1521134295 + EqualityComparer<int[]>.Default.GetHashCode(NewCarsBehind);
+            return hashCode;
+        }
+    }
+}

--- a/Components/IRacing/IIRacingEventFactory.cs
+++ b/Components/IRacing/IIRacingEventFactory.cs
@@ -48,7 +48,7 @@ namespace Slipstream.Components.IRacing
             bool bestLap
         );
 
-        IEvent CreateIRacingTowed(double sessionTime, float remainingTowTime);
+        IRacingTowed CreateIRacingTowed(double sessionTime, float remainingTowTime);
 
         IRacingCarInfo CreateIRacingCarInfo(
             double sessionTime,
@@ -178,5 +178,7 @@ namespace Slipstream.Components.IRacing
         IRacingCarPosition CreateIRacingCarPosition(double sessionTime, int carIdx, bool localUser, int positionInClass, int positionInRace);
 
         IRacingRaw CreateIRacingRaw(IState state);
+
+        IRacingTrackPosition CreateIRacingTrackPosition(double sessionTime, long carIdx, bool localUser, int currentPositionInRace, int currentPositionInClass, int previousPositionInRace, int previousPositionInClass, int[] newCarsAhead, int[] newCarsBehind);
     }
 }

--- a/Components/IRacing/Plugins/GameState/Car.cs
+++ b/Components/IRacing/Plugins/GameState/Car.cs
@@ -13,6 +13,7 @@
         public long IRating { get; set; }
         public string License { get; set; } = string.Empty;
         public bool IsSpectator { get; set; }
+        public int Laps { get; set; }
         public int LapsCompleted { get; set; }
         public bool OnPitRoad { get; set; }
         public int ClassPosition { get; set; }
@@ -21,6 +22,8 @@
         public double LastLapTime { get; set; }
         public float BestLapTime { get; set; }
         public int BestLapNum { get; set; }
+        public float LapDistPct { get; set; }
+        public long CarClassId { get; set; }
 
         public Car Clone()
         {
@@ -37,6 +40,7 @@
                 IRating = IRating,
                 License = License,
                 IsSpectator = IsSpectator,
+                Laps = Laps,
                 LapsCompleted = LapsCompleted,
                 OnPitRoad = OnPitRoad,
                 ClassPosition = ClassPosition,
@@ -45,6 +49,8 @@
                 LastLapTime = LastLapTime,
                 BestLapTime = BestLapTime,
                 BestLapNum = BestLapNum,
+                CarClassId = CarClassId,
+                LapDistPct = LapDistPct,
             };
         }
     }

--- a/Components/IRacing/Plugins/GameState/StateFactory.cs
+++ b/Components/IRacing/Plugins/GameState/StateFactory.cs
@@ -2,6 +2,7 @@
 
 using iRacingSDK;
 using System;
+using System.Linq;
 using System.Collections.Generic;
 using static Slipstream.Components.IRacing.IIRacingEventFactory;
 
@@ -121,6 +122,11 @@ namespace Slipstream.Components.IRacing.Plugins.GameState
                 foreach (var d in ds.SessionData.DriverInfo.Drivers)
                 {
                     int idx = (int)d.CarIdx;
+                    var location = (IIRacingEventFactory.CarLocation)(int)ds.Telemetry.CarIdxTrackSurface[idx];
+                    var lastLapTime = ((float[])ds.Telemetry["CarIdxLastLapTime"])[idx];
+                    var bestLapTime = ((float[])ds.Telemetry["CarIdxBestLapTime"])[idx];
+                    var bestLapNum = ((int[])ds.Telemetry["CarIdxBestLapNum"])[idx];
+                    var lapDistPct = ((float[])ds.Telemetry["CarIdxLapDistPct"])[idx];
 
                     var car = new Car
                     {
@@ -135,14 +141,17 @@ namespace Slipstream.Components.IRacing.Plugins.GameState
                         IRating = d.IRating,
                         License = d.LicString,
                         IsSpectator = d.IsSpectator != 0,
+                        Laps = ds.Telemetry.CarIdxLap[idx],
                         LapsCompleted = ds.Telemetry.CarIdxLapCompleted[idx],
                         OnPitRoad = ds.Telemetry.CarIdxOnPitRoad[idx],
                         ClassPosition = ds.Telemetry.CarIdxClassPosition[idx],
                         Position = ds.Telemetry.CarIdxPosition[idx],
-                        Location = (IIRacingEventFactory.CarLocation)(int)ds.Telemetry.CarIdxTrackSurface[idx],
-                        LastLapTime = ((float[])ds.Telemetry["CarIdxLastLapTime"])[idx],
-                        BestLapTime = ((float[])ds.Telemetry["CarIdxBestLapTime"])[idx],
-                        BestLapNum = ((int[])ds.Telemetry["CarIdxBestLapNum"])[idx],
+                        Location = location,
+                        LastLapTime = lastLapTime,
+                        BestLapTime = bestLapTime,
+                        BestLapNum = bestLapNum,
+                        LapDistPct = lapDistPct,
+                        CarClassId = ds.SessionData.DriverInfo.Drivers.Where(a => a.CarIdx == idx).Select(a => a.CarClassID).FirstOrDefault()
                     };
 
                     if (Cars.TryGetValue(idx, out Car existingCar))

--- a/Components/IRacing/Plugins/Trackers/TrackPositionTracker.cs
+++ b/Components/IRacing/Plugins/Trackers/TrackPositionTracker.cs
@@ -1,0 +1,462 @@
+﻿using Slipstream.Components.IRacing.Plugins.Models;
+using Slipstream.Shared;
+using System.Collections.Generic;
+using System.Linq;
+
+#nullable enable
+
+namespace Slipstream.Components.IRacing.Plugins.Trackers
+{
+    internal class TrackPositionTracker : IIRacingDataTracker
+    {
+        // Keep track of track positions is a bit complicated.
+        //
+        // The base idea is that we store an AbsolutePosition float, which is
+        // <lapnumber>.<pct-of-completed-lap>. Which means that if you are halfway
+        // through lap five, your position would be 5.5.
+        //
+        // By assigning an AbsolutePosition to all cars, we can simply sort the
+        // list from low-to-high, to determine what position they got right now.
+        //
+        // IRacing provides Laps and LapsCompleted for giving a lap-count and LapDistPct
+        // that represent where you are on the track on that given lap. So this can almost
+        // be used directly. We'll create a number in the format of <Lap>.<LapDistPct>,
+        // meaning that 4.32, means that we have completed 4 full laps, and is 32% into
+        // the next one.
+        //
+        // However,  race starts complicates it a bit. When before green LapsCompleted is
+        // -1 and Laps is 0. When we go green, both of them is increased by 1. So a starting
+        // car would have AbsolutePosition = 0.9 - as we're about to cross start/finish line.
+        //
+        // So far, our AbsolutePosition works nicely.
+        //
+        // Crossing s/f line after green, and thereby starting your first lap, will NOT increase
+        // LapsCompleted and Laps. So our car will now be at 0.1.. and cars that have not
+        // cross s/f will have 0.9-something. Sorting these values will appear as if the cars
+        // not crossed the s/f line is far ahead of the cars that did.
+        //
+        // To fix this, we try to detect the "PreLap". The lap we're on when we're green, before
+        // crossing s/f line. If this PreLap is true, we will subtract one from the lap value,
+        // so that cars that didnt cross s/f line, will be at -1.9, whilst cars that did will be at
+        // 0.2. Now our sorting works again.
+        //
+        // Related to this, some drivers starts from the pits. These cars will have position 0.9x
+        // so the cars on the track might seem behind the pitted cars. As starting from pits will
+        // make IRacing delay when you can start - you will eventually get on track after all the
+        // cars that started on the track. So to avoid a number of irrelevant overtakes, we'll
+        // ignore these cars until they exit the pits.
+        //
+        // Towed cars: When a car is towed to pits, the position is immediately changed to the
+        // position of of the pit stall. This gives some wierd effects.
+        // Say car A is at 3.5, and car B is at 3.7. Car A crashes and is towed, which means that
+        // the car will instantly be moved to 3.9 - overtaking car B. It will stay there for the
+        // duration of the towing, so car B will regain its position. But we'll end up having two
+        // overtakes, that isn't really worth reporting. So to get around this, I'm ignoring the
+        // new position if we're being towed. So car A will seemingly still be at 3.5. Once the
+        // car leaves the pits, it will then be zapped from 3.5 to 3.9.. It would be neat if we could
+        // avoid this. But we don't know how long the towing will take.
+
+        private class CarData
+        {
+            public float AbsolutePosition { get; set; }
+            public float LastAbsolutePosition { get; set; } // DEBUG
+            public int CurrentPositionInClass { get; set; }
+            public int CurrentPositionInRace { get; set; }
+            public int PreviousPositionInRace { get; set; }
+            public int PreviousPositionInClass { get; set; }
+            public int LastLap { get; set; }
+            public float LastLapDistPct { get; set; }
+            public bool PreLap { get; set; } = false;
+            public IIRacingEventFactory.CarLocation LastLocation { get; set; }
+            public bool IgnoredUntilOnTrack { get; set; } = false;
+            public double NotInWorldSince { get; set; } = -1;
+            public long CarClassId { get; set; }
+        }
+
+        private class PositionChange
+        {
+            public int CarIdx { get; set; }
+            public int CurrentPositionInRace { get; set; }
+            public int CurrentPositionInClass { get; set; }
+            public int PreviousPositionInRace { get; set; }
+            public int PreviousPositionInClass { get; set; }
+        }
+
+        private readonly IIRacingEventFactory EventFactory;
+        private readonly IEventBus EventBus;
+
+        private readonly Dictionary<int, CarData> LastCarData = new Dictionary<int, CarData>();
+        private int SessionNum = 0;
+        private double LastOverviewShownAt { get; set; }
+
+        private IIRacingEventFactory.IRacingSessionStateEnum LastSessionState = IIRacingEventFactory.IRacingSessionStateEnum.Invalid;
+
+        public TrackPositionTracker(IEventBus eventBus, IIRacingEventFactory eventFactory)
+        {
+            EventBus = eventBus;
+            EventFactory = eventFactory;
+        }
+
+        public void Handle(GameState.IState currentState, IRacingDataTrackerState state)
+        {
+            if (currentState.SessionNum != SessionNum)
+            {
+                LastCarData.Clear();
+                SessionNum = currentState.SessionNum;
+            }
+
+            if (currentState.SessionType != IIRacingEventFactory.IRacingSessionTypeEnum.Race)
+            {
+                return;
+            }
+
+            if (LastSessionState != currentState.SessionState)
+            {
+                Debug($"{currentState.SessionType}: {LastSessionState} -> {currentState.SessionState}");
+
+                // Populate our state
+                if (LastCarData.Count == 0 && (currentState.SessionState == IIRacingEventFactory.IRacingSessionStateEnum.Racing || currentState.SessionState == IIRacingEventFactory.IRacingSessionStateEnum.Warmup))
+                {
+                    InitializeTrackerState(currentState);
+                }
+
+                LastSessionState = currentState.SessionState;
+            }
+
+            if (currentState.SessionState != IIRacingEventFactory.IRacingSessionStateEnum.Racing)
+            {
+                return;
+            }
+
+            bool someoneIsBlinking = UpdateCarPositions(currentState);
+
+            // Don't calculate new positions if somebody is blinking.
+            if (someoneIsBlinking)
+                return;
+
+            RecalculatePositions(currentState);
+            PublishEvents(currentState);
+            ShowOverview(currentState);
+        }
+
+        private bool UpdateCarPositions(GameState.IState currentState)
+        {
+            var someoneIsBlinking = false;
+
+            // calculate positions
+            foreach (var car in currentState.Cars)
+            {
+                if (car.UserId != -1 && !car.IsSpectator) // ignore pacecar and spectators
+                    someoneIsBlinking = UpdateTrackerState(currentState, someoneIsBlinking, car);
+            }
+
+            return someoneIsBlinking;
+        }
+
+        private void ShowOverview(GameState.IState currentState)
+        {
+            if (currentState.SessionTime - LastOverviewShownAt > 60)
+            {
+                foreach (var orderedPosition in LastCarData
+                    .OrderByDescending(x => x.Value.AbsolutePosition)
+                    .ToList())
+                {
+                    Debug($"  p{orderedPosition.Value.CurrentPositionInRace}/{orderedPosition.Value.CurrentPositionInClass}  carIdx={orderedPosition.Key} {currentState.Cars[orderedPosition.Key].CarNumber} {currentState.Cars[orderedPosition.Key].UserName} {orderedPosition.Value.AbsolutePosition} {orderedPosition.Value.PreLap}/{orderedPosition.Value.LastLap} {orderedPosition.Value.LastLocation}");
+                }
+
+                LastOverviewShownAt = currentState.SessionTime;
+            }
+        }
+
+        private void PublishEvents(GameState.IState currentState)
+        {
+            var time = currentState.SessionTime;
+            var positionChanges = new List<PositionChange>();
+
+            foreach (var orderedPosition in LastCarData)
+            {
+                var carIdx = orderedPosition.Key;
+                var trackerCarState = orderedPosition.Value;
+
+                if (trackerCarState.CurrentPositionInRace == trackerCarState.PreviousPositionInRace)
+                {
+                    // No change, all no event
+                }
+                else
+                {
+                    // We gained/lost one or more positions
+                    positionChanges.Add(
+                        new PositionChange
+                        {
+                            CarIdx = carIdx,
+                            CurrentPositionInRace = trackerCarState.CurrentPositionInRace,
+                            PreviousPositionInRace = trackerCarState.PreviousPositionInRace,
+                            CurrentPositionInClass = trackerCarState.CurrentPositionInClass,
+                            PreviousPositionInClass = trackerCarState.PreviousPositionInClass,
+                        });
+                }
+            }
+
+            // We know the changes now, let's see if we can improve upon them
+            foreach (var change in positionChanges)
+            {
+                if (change.PreviousPositionInRace == 0)
+                {
+                    // The car didnt have a position before, so no need to send out event
+                    LastCarData[change.CarIdx].PreviousPositionInRace = LastCarData[change.CarIdx].CurrentPositionInRace;
+                }
+                else
+                {
+                    var newCarsAhead = new List<int>();
+                    var newCarsBehind = new List<int>();
+
+                    foreach (var otherCar in positionChanges.Where(a => a.CarIdx != change.CarIdx && a.CurrentPositionInRace != a.PreviousPositionInRace))
+                    {
+                        if (change.CurrentPositionInRace < otherCar.CurrentPositionInRace && change.PreviousPositionInRace >= otherCar.CurrentPositionInRace)
+                        {
+                            newCarsBehind.Add(otherCar.CarIdx);
+                        }
+                        else if (change.CurrentPositionInRace > otherCar.CurrentPositionInRace && change.PreviousPositionInRace <= otherCar.CurrentPositionInRace)
+                        {
+                            newCarsAhead.Add(otherCar.CarIdx);
+                        }
+                    }
+
+                    EventBus.PublishEvent(
+                        EventFactory.CreateIRacingTrackPosition(
+                            sessionTime: time,
+                            carIdx: change.CarIdx,
+                            localUser: currentState.DriverCarIdx == change.CarIdx,
+                            currentPositionInRace: change.CurrentPositionInRace,
+                            currentPositionInClass: change.CurrentPositionInClass,
+                            previousPositionInRace: change.PreviousPositionInRace,
+                            previousPositionInClass: change.PreviousPositionInClass,
+                            newCarsAhead: newCarsAhead.ToArray(),
+                            newCarsBehind: newCarsBehind.ToArray()
+                        )
+                    );
+                }
+
+                LastCarData[change.CarIdx].PreviousPositionInRace = LastCarData[change.CarIdx].CurrentPositionInRace;
+            }
+        }
+
+        private void RecalculatePositions(GameState.IState currentState)
+        {
+            int nextPositionInRace = 1;
+            var nextPositionInClass = new Dictionary<long, int>();
+            foreach (var orderedPosition in LastCarData
+                .Where(x => !x.Value.IgnoredUntilOnTrack)
+                .OrderByDescending(x => x.Value.AbsolutePosition)
+                .ToList())
+            {
+                var carIdx = orderedPosition.Key;
+                var trackerCarState = orderedPosition.Value;
+
+                if (!nextPositionInClass.ContainsKey(trackerCarState.CarClassId))
+                {
+                    nextPositionInClass.Add(trackerCarState.CarClassId, 1);
+                }
+                else
+                {
+                    nextPositionInClass[trackerCarState.CarClassId]++;
+                }
+
+                if (nextPositionInRace != trackerCarState.CurrentPositionInRace)
+                {
+                    Debug($"### {currentState.SessionTime} caridx-{carIdx}: carNumber={currentState.Cars[carIdx].CarNumber} PreLap={trackerCarState.PreLap}, Ignored={trackerCarState.IgnoredUntilOnTrack}, absPos={trackerCarState.LastAbsolutePosition} -> {trackerCarState.AbsolutePosition}, LastLap={trackerCarState.LastLap}, Location={currentState.Cars[carIdx].Location}: PositionInRace={trackerCarState.CurrentPositionInRace}->{nextPositionInRace}, PositionInClass={trackerCarState.CurrentPositionInClass}->{nextPositionInClass[trackerCarState.CarClassId]} {currentState.Cars[orderedPosition.Key].UserName}");
+
+                    trackerCarState.PreviousPositionInRace = trackerCarState.CurrentPositionInRace;
+                    trackerCarState.PreviousPositionInClass = trackerCarState.CurrentPositionInClass;
+                    trackerCarState.CurrentPositionInRace = nextPositionInRace;
+                    trackerCarState.CurrentPositionInClass = nextPositionInClass[trackerCarState.CarClassId];
+                }
+
+                nextPositionInRace++;
+            }
+        }
+
+        private bool UpdateTrackerState(GameState.IState currentState, bool someoneIsBlinking, GameState.Car car)
+        {
+            var carTrackerState = LastCarData[car.CarIdx];
+
+            carTrackerState.LastAbsolutePosition = carTrackerState.AbsolutePosition;
+
+            if (carTrackerState.IgnoredUntilOnTrack)
+            {
+                HandleIgnoredCar(car, carTrackerState);
+            }
+            else if (car.Location == IIRacingEventFactory.CarLocation.InPitStall && carTrackerState.LastLocation == IIRacingEventFactory.CarLocation.NotInWorld)
+            {
+                HandleTowedCar(car, carTrackerState);
+            }
+            else if (car.Location == IIRacingEventFactory.CarLocation.InPitStall && carTrackerState.IgnoredUntilOnTrack)
+            {
+                // Still being towed / in pits
+            }
+            else if (car.Location == IIRacingEventFactory.CarLocation.NotInWorld)
+            {
+                someoneIsBlinking = HandleCarNotInWorld(currentState, someoneIsBlinking, car, carTrackerState);
+            }
+            else
+            {
+                HandleRacingCar(currentState, car, carTrackerState);
+            }
+
+            return someoneIsBlinking;
+        }
+
+        private void HandleRacingCar(GameState.IState currentState, GameState.Car car, CarData carTrackerState)
+        {
+            // Car is racing
+
+            var lapDistPct = car.LapDistPct;
+
+            if (lapDistPct > 1)
+            {
+                Debug($"Fixing bad position for caridx-{car.CarIdx} {car.CarNumber}  - above 100% track completed!? {lapDistPct}");
+                lapDistPct = 1;
+            }
+
+            if (carTrackerState.PreLap)
+            {
+                var diff = carTrackerState.LastLapDistPct - lapDistPct;
+
+                if (diff > 0.9)
+                {
+                    Debug($"{currentState.SessionTime} caridx-{car.CarIdx} {car.CarNumber}: s/f crossed - diff {diff} - no more prelap");
+                    carTrackerState.PreLap = false;
+                }
+            }
+
+            /* Handle that IRacing will report:
+             * lapDistPct 0,9996102 of lap 0
+             * lapDistPct 0,9998848 of lap 1 <-- end of next lap!?
+             * lapDistPct 0,0001598561 of lap 1
+             */
+
+            if (car.Laps > carTrackerState.LastLap && lapDistPct > 0.9f)
+            {
+                Debug($"Fixing bad position for caridx-{car.CarIdx} car.Laps={car.Laps}, carTrackerState.LastLap={carTrackerState.LastLap}, lapDistPct={lapDistPct}");
+                lapDistPct = 0;
+            }
+
+            var laps = car.Laps;
+
+            if (carTrackerState.PreLap)
+            {
+                laps--;
+            }
+
+            carTrackerState.AbsolutePosition = (float)(laps + lapDistPct); // <lap>.<lapdistpctpct>
+            carTrackerState.LastLap = car.Laps;
+            carTrackerState.LastLapDistPct = lapDistPct;
+            carTrackerState.LastLocation = car.Location;
+            carTrackerState.IgnoredUntilOnTrack = false;
+            carTrackerState.NotInWorldSince = -1;
+        }
+
+        private bool HandleCarNotInWorld(GameState.IState currentState, bool someoneIsBlinking, GameState.Car car, CarData carTrackerState)
+        {
+            // This could be start of towing, or blinking.
+            carTrackerState.LastLocation = car.Location;
+
+            if (carTrackerState.NotInWorldSince == -1)
+            {
+                carTrackerState.NotInWorldSince = currentState.SessionTime;
+            }
+            else
+            {
+                var delta = currentState.SessionTime - carTrackerState.NotInWorldSince;
+
+                if (delta < 1)
+                {
+                    someoneIsBlinking = true;
+                }
+            }
+
+            return someoneIsBlinking;
+        }
+
+        private void HandleTowedCar(GameState.Car car, CarData carTrackerState)
+        {
+            Debug($"caridx = {car.CarIdx} {car.CarNumber} {car.UserName} is in pit stall after being notinworld. Towed or started from pits. Ignoring");
+
+            carTrackerState.LastLocation = car.Location;
+            carTrackerState.IgnoredUntilOnTrack = true;
+            carTrackerState.NotInWorldSince = -1;
+            // We dont update the position intentionally. We keep the old position and let other cars
+            // overtake us. Once we're leaving the pits, we'll update the position.
+        }
+
+        private void HandleIgnoredCar(GameState.Car car, CarData carTrackerState)
+        {
+            if (car.Location == IIRacingEventFactory.CarLocation.OnTrack || car.Location == IIRacingEventFactory.CarLocation.OffTrack)
+            {
+                Debug($"caridx-{car.CarIdx} is back on track. Stop ignoring {car.UserName}");
+                carTrackerState.IgnoredUntilOnTrack = false;
+                carTrackerState.PreLap = false;
+            }
+        }
+
+        private void InitializeTrackerState(GameState.IState currentState)
+        {
+            Debug("** POPULATING **");
+
+            LastOverviewShownAt = currentState.SessionTime;
+
+            foreach (var car in currentState.Cars)
+            {
+                if (car.UserId != -1 && !car.IsSpectator)
+                {
+                    var ignoredUntilOnTrack = car.Location == IIRacingEventFactory.CarLocation.InPitStall;
+                    var preLap = car.Laps == 1 && LastSessionState != IIRacingEventFactory.IRacingSessionStateEnum.Invalid; // Initially lastsessionstate is invalid, so if we see it here, it mean that we're dropped directly into a race without any warmup/getincar/paradealps etc
+                    var laps = car.Laps;
+                    var lapDistPct = car.LapDistPct;
+
+                    // Some tracks some of the cars starts in front of the s/f line (like Bathurst) and the
+                    // rest behind the line. To properly be able to sort this, we'll pretend they are a
+                    // lap down, so they dont get calculated as in front of everbody. We do this by setting
+                    // preLap
+
+                    if (lapDistPct > 0.5)
+                    {
+                        preLap = true;
+                    }
+
+                    Debug($"{currentState.SessionTime} Hello caridx-#{car.CarIdx} {car.CarNumber} {car.UserName} laps={car.Laps}, LapDistPct={car.LapDistPct}, PreLap={preLap}, Location={car.Location}, IgnoredUntilOnTrack={ignoredUntilOnTrack}");
+
+                    if (preLap)
+                    {
+                        laps--;
+                    }
+
+                    LastCarData.Add(car.CarIdx, new CarData
+                    {
+                        AbsolutePosition = laps + car.LapDistPct,
+                        CurrentPositionInClass = car.ClassPosition,
+                        CurrentPositionInRace = car.Position,
+                        LastLap = laps,
+                        LastLapDistPct = car.LapDistPct,
+                        LastLocation = car.Location,
+                        PreLap = preLap,
+                        IgnoredUntilOnTrack = ignoredUntilOnTrack,
+                        CarClassId = car.CarClassId,
+                    });
+                }
+                else
+                {
+                    Debug($"Ignoring {car.CarIdx} {car.UserName}");
+                }
+            }
+        }
+
+#pragma warning disable IDE0060 // Remove unused parameter
+
+        private void Debug(string str)
+#pragma warning restore IDE0060 // Remove unused parameter
+        {
+            //System.Diagnostics.Debug.WriteLine(str);
+        }
+    }
+}

--- a/Components/IRacing/Plugins/Trackers/Trackers.cs
+++ b/Components/IRacing/Plugins/Trackers/Trackers.cs
@@ -29,6 +29,7 @@ namespace Slipstream.Components.IRacing.Plugins.Trackers
             DataTrackers.Add(new IRacingSessionTracker(eventBus, eventFactory));
             DataTrackers.Add(new CarPositionTracker(eventBus, eventFactory));
             DataTrackers.Add(new TowTracker(eventBus, eventFactory));
+            DataTrackers.Add(new TrackPositionTracker(eventBus, eventFactory));
         }
 
         public void Handle(GameState.IState currentState)

--- a/Components/IRacing/README.md
+++ b/Components/IRacing/README.md
@@ -563,3 +563,28 @@ Published every your car is being towed to pits. You will not get these events f
 **JSON Example:**
 `{"EventType":"IRacingTowed","ExcludeFromTxrx":false,"Uptime":2528216,"SessionTime":2711.7666666666669,"CarIdx":28,"LocalUser":true,"PositionInClass":15,"PositionInRace":15}`
 </details>
+
+<details><summary>IRacingTrackPosition</summary><br />
+
+Published every time a car changes position (overtakes or get overtaken). Mostly, there
+will only be on other car in the event (in `NewCarsAhead` or `NewCarsBehind`)
+
+| Name                    | Type     | Description                                                       |
+|:------------------------|:--------:|:------------------------------------------------------------------|
+| EventType               | string   | `IRacingTrackPosition` (constant)                                 |
+| ExcludeFromTxrx         | boolean  | false (constant)                                                  |
+| Uptime                  | integer  | Time of when the message was sent via Eventbus (in milliseconds). |
+| SessionTime             | float    |                                                                   |
+| CarIdx                  | int      | Car Index                                                         |
+| LocalUser               | boolean  | Is it our car?                                                    |
+| CurrentPositionInClass  | int      | Our current position in our class.                                |
+| CurrentPositionInRace   | int      | Our current position in race.                                     |
+| PreviousPositionInClass | int      | Our current position in our class.                                |
+| PreviousPositionInRace  | int      | Our current position in race.                                     |
+| NewCarsAhead            | [CarIdx] | Array of new CarIdx that overtook the car                         |
+| NewCarsBehind           | [CarIdx] | Array of new CarIdx that car overtook                             |
+**JSON Example:**
+`{"EventType":"IRacingTrackPosition","ExcludeFromTxrx":false,"Uptime":63990,"SessionTime":360.383321126302,"CarIdx":39,"LocalUser":true,"CurrentPositionInClass":35,"CurrentPositionInRace":35,"PreviousPositionInClass":34,"PreviousPositionInRace":34,"NewCarsAhead":[7],"NewCarsBehind":[]}`
+</details>
+
+

--- a/Slipstream.UnitTests/Components/IRacing/Plugins/Trackers/TrackPositionTrackerTests.cs
+++ b/Slipstream.UnitTests/Components/IRacing/Plugins/Trackers/TrackPositionTrackerTests.cs
@@ -1,0 +1,95 @@
+﻿using Slipstream.Components.IRacing;
+using Slipstream.Components.IRacing.EventFactory;
+using Slipstream.Components.IRacing.Events;
+using Slipstream.Components.IRacing.Plugins.Models;
+using Slipstream.Components.IRacing.Plugins.Trackers;
+using System.Linq;
+using Slipstream.UnitTests.TestData;
+using Xunit;
+
+namespace Slipstream.UnitTests.Components.IRacing.Plugins.Trackers
+{
+    public class TrackPositionTrackerTest
+    {
+        private readonly TestEventBus EventBus;
+        private readonly IIRacingEventFactory EventFactory;
+        private readonly IRacingDataTrackerState TrackerState;
+        private readonly GameStateBuilder Builder;
+
+        public TrackPositionTrackerTest()
+        {
+            EventBus = new TestEventBus();
+            EventFactory = new IRacingEventFactory();
+            TrackerState = new IRacingDataTrackerState();
+            Builder = new GameStateBuilder();
+        }
+
+        [Fact]
+        public void CarOvertakesOtherCarInDifferentClass()
+        {
+            const float NOW = 1234.2f;
+
+            // arrange
+
+            // car0 is front of car1
+            Builder
+                .AtSessionTime(NOW)
+                .Set(a => a.DriverCarIdx = 0)
+                .Set(a => a.SessionType = IIRacingEventFactory.IRacingSessionTypeEnum.Race)
+                .Set(a => a.SessionState = IIRacingEventFactory.IRacingSessionStateEnum.Racing)
+                .Car(0).OnTrack().Set(a => a.CarClassId = 1).Set(a => a.LapDistPct = 0.44f).CarDone()
+                .Car(1).OnTrack().Set(a => a.CarClassId = 2).Set(a => a.LapDistPct = 0.40f).CarDone()
+                .Commit();
+            // car1 overtakes car0
+            Builder
+                .AtSessionTime(NOW + 1)
+                .Car(0).OnTrack().Set(a => a.LapDistPct = 0.44f).CarDone()
+                .Car(1).OnTrack().Set(a => a.LapDistPct = 0.50f).CarDone()
+                .Commit();
+
+            // act
+            var sut = new TrackPositionTracker(EventBus, EventFactory);
+            foreach (var s in Builder.States)
+                sut.Handle(s, TrackerState);
+
+            // assert
+            Assert.True(EventBus.Events.Count == 2);
+
+            foreach (var rawEvent in EventBus.Events)
+            {
+                var @event = rawEvent as IRacingTrackPosition;
+
+                Assert.NotNull(@event);
+                Assert.True(@event.SessionTime == NOW + 1);
+
+                // class-wise, there isn't any change, as the two cars are in
+                // different class.
+
+                if (@event.CarIdx == 0)
+                {
+                    Assert.True(@event.LocalUser);
+                    Assert.True(@event.PreviousPositionInRace == 1);
+                    Assert.True(@event.CurrentPositionInRace == 2);
+                    Assert.True(@event.PreviousPositionInClass == 1);
+                    Assert.True(@event.CurrentPositionInClass == 1);
+                    Assert.True(@event.NewCarsAhead.SequenceEqual(new int[] { 1 }));
+                    Assert.True(@event.NewCarsBehind.Length == 0);
+                }
+                else if (@event.CarIdx == 1)
+                {
+                    Assert.False(@event.LocalUser);
+                    Assert.True(@event.PreviousPositionInRace == 2);
+                    Assert.True(@event.CurrentPositionInRace == 1);
+                    Assert.True(@event.PreviousPositionInClass == 1);
+                    Assert.True(@event.CurrentPositionInClass == 1);
+                    Assert.True(@event.NewCarsAhead.Length == 0);
+                    Assert.True(@event.NewCarsBehind.SequenceEqual(new int[] { 0 }));
+                }
+                else
+                {
+                    Assert.Null("Unexpected caridx");
+                }
+            }
+        }
+    }
+}

--- a/Slipstream.UnitTests/TestData/GameStateBuilder.cs
+++ b/Slipstream.UnitTests/TestData/GameStateBuilder.cs
@@ -57,8 +57,8 @@ namespace Slipstream.UnitTests.TestData
 
         public class CarBuilder
         {
-            private GameStateBuilder Builder;
-            private int CarIdx;
+            private readonly GameStateBuilder Builder;
+            private readonly int CarIdx;
             private Car Car { get => Builder.Cars[CarIdx]; }
 
             public CarBuilder(GameStateBuilder b, int carIdx)
@@ -69,7 +69,7 @@ namespace Slipstream.UnitTests.TestData
                 Debug.Assert(b.Cars.Count >= carIdx);
                 if (b.Cars.Count == carIdx)
                 {
-                    b.Cars.Add(new Car());
+                    b.Cars.Add(new Car { CarIdx = carIdx });
                 }
             }
 
@@ -150,6 +150,11 @@ namespace Slipstream.UnitTests.TestData
             public void Commit()
             {
                 Builder.Commit();
+            }
+
+            public GameStateBuilder CarDone()
+            {
+                return Builder;
             }
         }
 

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -193,6 +193,7 @@
     <Compile Include="Components\Internal\LuaGLues\HttpLuaGlueFactory.cs" />
     <Compile Include="Components\Internal\LuaGLues\CoreLuaGlueFactory.cs" />
     <Compile Include="Components\Internal\Internal.cs" />
+    <Compile Include="Components\IRacing\Events\IRacingTrackPosition.cs" />
     <Compile Include="Components\IRacing\Events\IRacingTowed.cs" />
     <Compile Include="Components\IRacing\Events\IRacingRaw.cs" />
     <Compile Include="Components\IRacing\LuaGlueFactory.cs" />
@@ -210,6 +211,7 @@
     <Compile Include="Components\IRacing\Plugins\Models\DriverState.cs" />
     <Compile Include="Components\IRacing\Plugins\Trackers\CarInfoTracker.cs" />
     <Compile Include="Components\IRacing\Plugins\Trackers\CarPositionTracker.cs" />
+    <Compile Include="Components\IRacing\Plugins\Trackers\TrackPositionTracker.cs" />
     <Compile Include="Components\IRacing\Plugins\Trackers\TowTracker.cs" />
     <Compile Include="Components\IRacing\Plugins\Trackers\IRacingSessionTracker.cs" />
     <Compile Include="Components\IRacing\Plugins\Trackers\PitUsageTracker.cs" />


### PR DESCRIPTION
IRacingTrackPosition is published on every change - when a car gets
overtaken or overtakes anohter car

 - It is only tested with road races, so currently it ignores anything else (see https://github.com/dennis/slipstream/blob/iracing-position-tracking/Components/IRacing/Plugins/Trackers/TrackPositionTracker.cs#L104-L108)
 - Code is untested