### PR TITLE
Make DiscordPlugin usable again

### DIFF
--- a/Components/Discord/Plugins/DiscordPlugin.cs
+++ b/Components/Discord/Plugins/DiscordPlugin.cs
@@ -27,7 +27,7 @@ namespace Slipstream.Components.Discord.Plugins
             ConfigurationValidator = new DictionaryValidator().RequireString("token");
         }
 
-        public DiscordPlugin(IEventHandlerController eventHandlerController, string pluginId, IEventBus eventBus, IDiscordEventFactory eventFactory, Parameters configuration) : base(eventHandlerController, pluginId, "DiscordPlugin", "DiscordPlugin", true)
+        public DiscordPlugin(IEventHandlerController eventHandlerController, string id, IEventBus eventBus, IDiscordEventFactory eventFactory, Parameters configuration) : base(eventHandlerController, id, "DiscordPlugin", "DiscordPlugin", true)
         {
             ConfigurationValidator.Validate(configuration);
 


### PR DESCRIPTION
AutoFac were expecting a "id", not "pluginId", so it would fail hard