### PR TITLE
Reimplement application update using AutoUpdaterDotNET

### DIFF
--- a/Components/AppilcationUpdate/Lua/ApplicationUpdateLuaLibrary.cs
+++ b/Components/AppilcationUpdate/Lua/ApplicationUpdateLuaLibrary.cs
@@ -8,7 +8,7 @@ using System.Diagnostics;
 
 namespace Slipstream.Components.AppilcationUpdate.Lua
 {
-    public class ApplicationUpdateLuaLibrary : BaseLuaLibrary<IApplicationUpdateInstanceThread, IApplicationUpdateReference>
+    public class ApplicationUpdateLuaLibrary : SingletonLuaLibrary<IApplicationUpdateInstanceThread, IApplicationUpdateReference>
     {
         private static readonly DictionaryValidator ConfigurationValidator;
 

--- a/Components/AppilcationUpdate/Lua/ApplicationUpdateReference.cs
+++ b/Components/AppilcationUpdate/Lua/ApplicationUpdateReference.cs
@@ -1,14 +1,27 @@
-﻿namespace Slipstream.Components.AppilcationUpdate.Lua
+﻿using Slipstream.Shared;
+
+namespace Slipstream.Components.AppilcationUpdate.Lua
 {
     public class ApplicationUpdateReference : IApplicationUpdateReference
     {
         private ApplicationUpdateLuaLibrary LuaLibrary { get; }
         public string InstanceId { get; }
 
-        public ApplicationUpdateReference(ApplicationUpdateLuaLibrary luaLibrary, string instanceId)
+        private readonly IApplicationUpdateEventFactory ApplicationUpdateEventFactory;
+        private readonly IEventBus EventBus;
+
+        public ApplicationUpdateReference(ApplicationUpdateLuaLibrary luaLibrary, string instanceId, IEventBus eventBus, IApplicationUpdateEventFactory eventFactory)
         {
             LuaLibrary = luaLibrary;
             InstanceId = instanceId;
+            ApplicationUpdateEventFactory = eventFactory;
+            EventBus = eventBus;
+        }
+
+        [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
+        public void start()
+        {
+            EventBus.PublishEvent(ApplicationUpdateEventFactory.CreateApplicationUpdateCommandCheckLatestVersion());
         }
 
         public void Dispose()

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -1,5 +1,4 @@
 ﻿<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="packages\squirrel.windows.2.0.1\build\squirrel.windows.props" Condition="Exists('packages\squirrel.windows.2.0.1\build\squirrel.windows.props')" />
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -58,6 +57,9 @@
   <ItemGroup>
     <Reference Include="Autofac, Version=6.1.0.0, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
       <HintPath>packages\Autofac.6.1.0\lib\netstandard2.0\Autofac.dll</HintPath>
+    </Reference>
+    <Reference Include="AutoUpdater.NET, Version=1.6.4.0, Culture=neutral, PublicKeyToken=501435c91b35f4bc, processorArchitecture=MSIL">
+      <HintPath>packages\Autoupdater.NET.Official.1.6.4\lib\net45\AutoUpdater.NET.dll</HintPath>
     </Reference>
     <Reference Include="DeltaCompressionDotNet, Version=1.1.0.0, Culture=neutral, PublicKeyToken=1d14d6e5194e7f4a, processorArchitecture=MSIL">
       <HintPath>packages\DeltaCompressionDotNet.1.1.0\lib\net20\DeltaCompressionDotNet.dll</HintPath>
@@ -122,9 +124,6 @@
     <Reference Include="NLua, Version=1.5.7.0, Culture=neutral, PublicKeyToken=6a194c04b9c89217, processorArchitecture=MSIL">
       <HintPath>packages\NLua.1.5.7\lib\net46\NLua.dll</HintPath>
     </Reference>
-    <Reference Include="NuGet.Squirrel, Version=3.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\squirrel.windows.2.0.1\lib\Net45\NuGet.Squirrel.dll</HintPath>
-    </Reference>
     <Reference Include="Serilog, Version=2.0.0.0, Culture=neutral, PublicKeyToken=24c2f752a8e58a10, processorArchitecture=MSIL">
       <HintPath>packages\Serilog.2.10.0\lib\net46\Serilog.dll</HintPath>
     </Reference>
@@ -133,9 +132,6 @@
     </Reference>
     <Reference Include="SharpCompress, Version=0.17.1.0, Culture=neutral, PublicKeyToken=afb0a02973931d96, processorArchitecture=MSIL">
       <HintPath>packages\SharpCompress.0.17.1\lib\net45\SharpCompress.dll</HintPath>
-    </Reference>
-    <Reference Include="Squirrel, Version=2.0.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>packages\squirrel.windows.2.0.1\lib\Net45\Squirrel.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Buffers, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
@@ -173,6 +169,7 @@
     <Reference Include="System.ValueTuple, Version=4.0.3.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
       <HintPath>packages\System.ValueTuple.4.5.0\lib\net47\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />
@@ -497,7 +494,6 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('packages\squirrel.windows.2.0.1\build\squirrel.windows.props')" Text="$([System.String]::Format('$(ErrorText)', 'packages\squirrel.windows.2.0.1\build\squirrel.windows.props'))" />
     <Error Condition="!Exists('packages\KeraLua.1.2.13\build\net46\KeraLua.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\KeraLua.1.2.13\build\net46\KeraLua.targets'))" />
   </Target>
   <Target Name="AfterBuild" Condition=" '$(Configuration)' == 'Release'">

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="6.1.0" targetFramework="net472" />
+  <package id="Autoupdater.NET.Official" version="1.6.4" targetFramework="net472" />
   <package id="DeltaCompressionDotNet" version="1.1.0" targetFramework="net472" />
   <package id="DSharpPlus" version="3.2.3" targetFramework="net472" />
   <package id="KeraLua" version="1.2.13" targetFramework="net472" />
@@ -20,7 +21,6 @@
   <package id="Serilog" version="2.10.0" targetFramework="net472" />
   <package id="Serilog.Sinks.Console" version="3.1.1" targetFramework="net472" />
   <package id="sharpcompress" version="0.17.1" targetFramework="net472" />
-  <package id="squirrel.windows" version="2.0.1" targetFramework="net472" />
   <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
   <package id="System.Diagnostics.DiagnosticSource" version="4.7.1" targetFramework="net472" />
   <package id="System.Memory" version="4.5.4" targetFramework="net472" />


### PR DESCRIPTION
It seems that Squirrel.Windows is dying. There have been an
vulnerbility[0] for in one of the dependencies, discovered on september
12th, 2019, that can be fixed by merely releasing a new version with
updated dependency. It's a trivial task, yet it wasn't done.

Also it seems that there was an attempt[1], but that didn't really find
new maintainers. electron consider the project as not maintained[2]

0: https://github.com/advisories/GHSA-fxh6-w476-hgr4
1: https://github.com/Squirrel/Squirrel.Windows/issues/1470
2: https://github.com/electron/electron/issues/17722