### PR TITLE
UI can crash because of missing STAThreadAttribute

### DIFF
--- a/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
+++ b/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
@@ -4,6 +4,7 @@ using Slipstream.Components.UI;
 using Slipstream.Components.WinFormUI.Forms;
 using Slipstream.Shared;
 using Slipstream.Shared.Lua;
+using System;
 using System.Windows.Forms;
 
 namespace Slipstream.Components.WinFormUI.Lua
@@ -35,6 +36,7 @@ namespace Slipstream.Components.WinFormUI.Lua
             PlaybackEventFactory = playbackEventFactory;
         }
 
+        [STAThreadAttribute]
         protected override void Main()
         {
             Application.Run(new MainWindow(


### PR DESCRIPTION
UI sometimes throws this exception:

 Current thread must be set to single thread apartment (STA) mode before OLE calls can be made. Ensure that your Main function has STAThreadAttribute marked on it.