### PR TITLE
BUGFIX: Dont stop restarted instances immediately

### DIFF
--- a/Shared/Lua/BaseInstanceThread.cs
+++ b/Shared/Lua/BaseInstanceThread.cs
@@ -68,6 +68,8 @@ namespace Slipstream.Shared.Lua
             }
             else if (ServiceThread?.ThreadState == ThreadState.Stopped)
             {
+                Stopping = false;
+
                 // We need to recreate it
                 SetupThread();
                 ServiceThread.Start();


### PR DESCRIPTION
If a lua script stops for some reason, and we restart it, it would
immediately stop again, as the "Stopping" flag wasn't reset to false.