### PR TITLE
Simplify instance tracking

### DIFF
--- a/Components/AppilcationUpdate/Lua/ApplicationUpdateLuaLibrary.cs
+++ b/Components/AppilcationUpdate/Lua/ApplicationUpdateLuaLibrary.cs
@@ -21,7 +21,7 @@ namespace Slipstream.Components.AppilcationUpdate.Lua
                 .PermitBool("prerelease");
         }
 
-        public ApplicationUpdateLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public ApplicationUpdateLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/AppilcationUpdate/Lua/ApplicationUpdateReference.cs
+++ b/Components/AppilcationUpdate/Lua/ApplicationUpdateReference.cs
@@ -5,13 +5,11 @@ namespace Slipstream.Components.AppilcationUpdate.Lua
 {
     public class ApplicationUpdateReference : BaseLuaReference, IApplicationUpdateReference
     {
-        private ApplicationUpdateLuaLibrary LuaLibrary { get; }
         private readonly IApplicationUpdateEventFactory ApplicationUpdateEventFactory;
         private readonly IEventBus EventBus;
 
-        public ApplicationUpdateReference(ApplicationUpdateLuaLibrary luaLibrary, string instanceId, string luaScriptInstanceId, IEventBus eventBus, IApplicationUpdateEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
+        public ApplicationUpdateReference(string instanceId, string luaScriptInstanceId, IEventBus eventBus, IApplicationUpdateEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
             ApplicationUpdateEventFactory = eventFactory;
             EventBus = eventBus;
         }
@@ -20,11 +18,6 @@ namespace Slipstream.Components.AppilcationUpdate.Lua
         public void start()
         {
             EventBus.PublishEvent(ApplicationUpdateEventFactory.CreateApplicationUpdateCommandCheckLatestVersion(Envelope));
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
     }
 }

--- a/Components/Audio/Lua/AudioLuaLibrary.cs
+++ b/Components/Audio/Lua/AudioLuaLibrary.cs
@@ -21,7 +21,7 @@ namespace Slipstream.Components.Audio.Lua
                 .PermitLong("output");
         }
 
-        public AudioLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public AudioLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/Audio/Lua/AudioLuaReference.cs
+++ b/Components/Audio/Lua/AudioLuaReference.cs
@@ -9,12 +9,10 @@ namespace Slipstream.Components.Audio.Lua
     {
         private readonly IEventBus EventBus;
         private readonly IAudioEventFactory EventFactory;
-        private readonly AudioLuaLibrary LuaLibrary;
         private float Volume = 1.0f;
 
-        public AudioLuaReference(AudioLuaLibrary luaLibrary, string instanceId, string luaScriptInstanceId, IEventBus eventBus, IAudioEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
+        public AudioLuaReference(string instanceId, string luaScriptInstanceId, IEventBus eventBus, IAudioEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
             EventBus = eventBus;
             EventFactory = eventFactory;
         }
@@ -47,11 +45,6 @@ namespace Slipstream.Components.Audio.Lua
         public void set_volume(float volume)
         {
             Volume = volume;
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
     }
 }

--- a/Components/Discord/Lua/DiscordLuaChannelReference.cs
+++ b/Components/Discord/Lua/DiscordLuaChannelReference.cs
@@ -16,10 +16,6 @@ namespace Slipstream.Components.Discord.Lua
             EventFactory = eventFactory;
         }
 
-        public override void Dispose()
-        {
-        }
-
         public void send_message(string message)
         {
             EventBus.PublishEvent(EventFactory.CreateDiscordCommandSendMessage(Envelope, ChannelId, message, false));

--- a/Components/Discord/Lua/DiscordLuaLibrary.cs
+++ b/Components/Discord/Lua/DiscordLuaLibrary.cs
@@ -20,7 +20,7 @@ namespace Slipstream.Components.Discord.Lua
                 .RequireString("token");
         }
 
-        public DiscordLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public DiscordLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/Discord/Lua/DiscordLuaReference.cs
+++ b/Components/Discord/Lua/DiscordLuaReference.cs
@@ -8,12 +8,10 @@ namespace Slipstream.Components.Discord.Lua
     public class DiscordLuaReference : BaseLuaReference, ILuaReference
     {
         private readonly ILifetimeScope LifetimeScope;
-        private readonly DiscordLuaLibrary LuaLibrary;
 
-        public DiscordLuaReference(string instanceId, string luaScriptInstanceId, DiscordLuaLibrary luaLibrary, ILifetimeScope lifetimeScope) : base(instanceId, luaScriptInstanceId)
+        public DiscordLuaReference(string instanceId, string luaScriptInstanceId, ILifetimeScope lifetimeScope) : base(instanceId, luaScriptInstanceId)
         {
             LifetimeScope = lifetimeScope;
-            LuaLibrary = luaLibrary;
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
@@ -22,11 +20,6 @@ namespace Slipstream.Components.Discord.Lua
             return LifetimeScope.Resolve<IDiscordLuaChannelReference>(
                 new NamedParameter("instanceId", InstanceId),
                 new NamedParameter("channelId", channelId));
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
     }
 }

--- a/Components/FileMonitor/Lua/FileMonitorLuaLibrary.cs
+++ b/Components/FileMonitor/Lua/FileMonitorLuaLibrary.cs
@@ -23,7 +23,7 @@ namespace Slipstream.Components.FileMonitor.Lua
                 .RequireArray("paths", (a) => a.RequireString());
         }
 
-        public FileMonitorLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public FileMonitorLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/FileMonitor/Lua/FileMonitorLuaReference.cs
+++ b/Components/FileMonitor/Lua/FileMonitorLuaReference.cs
@@ -7,23 +7,16 @@ namespace Slipstream.Components.FileMonitor.Lua
     {
         private readonly IEventBus EventBus;
         private readonly IFileMonitorEventFactory EventFactory;
-        private readonly FileMonitorLuaLibrary LuaLibrary;
 
-        public FileMonitorLuaReference(string instanceId, string luaScriptInstanceId, FileMonitorLuaLibrary luaLibrary, IEventBus eventBus, IFileMonitorEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
+        public FileMonitorLuaReference(string instanceId, string luaScriptInstanceId, IEventBus eventBus, IFileMonitorEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
         {
             EventBus = eventBus;
             EventFactory = eventFactory;
-            LuaLibrary = luaLibrary;
         }
 
         public void scan()
         {
             EventBus.PublishEvent(EventFactory.CreateFileMonitorCommandScan(Envelope));
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
     }
 }

--- a/Components/IRacing/Lua/IRacingLuaLibrary.cs
+++ b/Components/IRacing/Lua/IRacingLuaLibrary.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using Autofac;
-using Slipstream.Components.Internal;
 using Slipstream.Shared;
 using Slipstream.Shared.Helpers.StrongParameters;
 using Slipstream.Shared.Helpers.StrongParameters.Validators;
@@ -20,7 +19,7 @@ namespace Slipstream.Components.IRacing.Lua
                 .PermitBool("send_raw_state");
         }
 
-        public IRacingLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public IRacingLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/IRacing/Lua/IRacingReference.cs
+++ b/Components/IRacing/Lua/IRacingReference.cs
@@ -7,18 +7,11 @@ namespace Slipstream.Components.IRacing.Lua
     {
         private readonly IEventBus EventBus;
         private readonly IIRacingEventFactory EventFactory;
-        private readonly IRacingLuaLibrary LuaLibrary;
 
-        public IRacingReference(string instanceId, string luaScriptInstanceId,  IRacingLuaLibrary luaLibrary, IEventBus eventBus, IIRacingEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
+        public IRacingReference(string instanceId, string luaScriptInstanceId, IEventBus eventBus, IIRacingEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
         {
             EventBus = eventBus;
             EventFactory = eventFactory;
-            LuaLibrary = luaLibrary;
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
 
         public void send_car_info()

--- a/Components/Internal/EventFactory/InternalEventFactory.cs
+++ b/Components/Internal/EventFactory/InternalEventFactory.cs
@@ -12,18 +12,18 @@ namespace Slipstream.Components.Internal.EventFactory
             return new InternalCommandShutdown { Envelope = envelope };
         }
 
-        public InternalInstanceAddSubscription CreateInternalInstanceAddSubscription(IEventEnvelope envelope, string instanceId)
+        public InternalAddDependency CreateInternalAddDependency(IEventEnvelope envelope, string instanceId)
         {
-            return new InternalInstanceAddSubscription
+            return new InternalAddDependency
             {
                 Envelope = envelope,
                 InstanceId = instanceId,
             };
         }
 
-        public InternalInstanceRemoveSubscription CreateInternalInstanceRemoveSubscription(IEventEnvelope envelope, string instanceId)
+        public InternalRemoveDependency CreateInternalRemoveDependency(IEventEnvelope envelope, string instanceId)
         {
-            return new InternalInstanceRemoveSubscription
+            return new InternalRemoveDependency
             {
                 Envelope = envelope,
                 InstanceId = instanceId,

--- a/Components/Internal/EventHandler/Internal.cs
+++ b/Components/Internal/EventHandler/Internal.cs
@@ -9,16 +9,18 @@ namespace Slipstream.Components.Internal.EventHandler
     internal class Internal : IEventHandler
     {
         public event EventHandler<InternalCommandShutdown>? OnInternalCommandShutdown;
-        public event EventHandler<InternalInstanceAddSubscription>? OnInternalInstanceAddSubscription;
-        public event EventHandler<InternalInstanceRemoveSubscription>? OnInternalInstanceRemoveSubscription;
+
+        public event EventHandler<InternalAddDependency>? OnInternaAddDependency;
+
+        public event EventHandler<InternalRemoveDependency>? OnInternalRemoveDependency;
 
         public IEventHandler.HandledStatus HandleEvent(IEvent @event)
         {
             return @event switch
             {
                 InternalCommandShutdown tev => OnEvent(OnInternalCommandShutdown, tev),
-                InternalInstanceAddSubscription tev => OnEvent(OnInternalInstanceAddSubscription, tev),
-                InternalInstanceRemoveSubscription tev => OnEvent(OnInternalInstanceRemoveSubscription, tev),
+                InternalAddDependency tev => OnEvent(OnInternaAddDependency, tev),
+                InternalRemoveDependency tev => OnEvent(OnInternalRemoveDependency, tev),
                 _ => IEventHandler.HandledStatus.NotMine,
             };
         }

--- a/Components/Internal/Events/InternalAddDependency.cs
+++ b/Components/Internal/Events/InternalAddDependency.cs
@@ -4,12 +4,12 @@ using Slipstream.Shared;
 
 namespace Slipstream.Components.Internal.Events
 {
-    public class InternalInstanceAddSubscription : IEvent
+    public class InternalAddDependency : IEvent
     {
-        public string EventType => nameof(InternalInstanceAddSubscription);
-        
+        public string EventType => nameof(InternalAddDependency);
+
         public IEventEnvelope Envelope { get; set; } = new EventEnvelope();
-        
+
         public string InstanceId { get; set; } = string.Empty;
     }
 }

--- a/Components/Internal/Events/InternalRemoveDependency.cs
+++ b/Components/Internal/Events/InternalRemoveDependency.cs
@@ -4,12 +4,12 @@ using Slipstream.Shared;
 
 namespace Slipstream.Components.Internal.Events
 {
-    public class InternalInstanceRemoveSubscription : IEvent
+    public class InternalRemoveDependency : IEvent
     {
-        public string EventType => nameof(InternalInstanceRemoveSubscription);
-        
+        public string EventType => nameof(InternalRemoveDependency);
+
         public IEventEnvelope Envelope { get; set; } = new EventEnvelope();
-        
+
         public string InstanceId { get; set; } = string.Empty;
     }
 }

--- a/Components/Internal/IInternalEventFactory.cs
+++ b/Components/Internal/IInternalEventFactory.cs
@@ -8,7 +8,9 @@ namespace Slipstream.Components.Internal
     public interface IInternalEventFactory
     {
         InternalCommandShutdown CreateInternalCommandShutdown(IEventEnvelope envelope);
-        InternalInstanceAddSubscription CreateInternalInstanceAddSubscription(IEventEnvelope envelope, string instanceId);
-        InternalInstanceRemoveSubscription CreateInternalInstanceRemoveSubscription(IEventEnvelope envelope, string instanceId);
+
+        InternalAddDependency CreateInternalAddDependency(IEventEnvelope envelope, string instanceId);
+
+        InternalRemoveDependency CreateInternalRemoveDependency(IEventEnvelope envelope, string instanceId);
     }
 }

--- a/Components/Lua/Lua/InternalLuaReference.cs
+++ b/Components/Lua/Lua/InternalLuaReference.cs
@@ -10,25 +10,18 @@ namespace Slipstream.Components.Lua.Lua
     {
         private readonly IEventBus EventBus;
         private readonly IInternalEventFactory EventFactory;
-        private readonly InternalLuaLibrary LuaLibrary;
         private readonly IEventEnvelope Envelope;
 
         public string InstanceId { get; }
         public string LuaScriptInstanceId { get; }
 
-        public InternalLuaReference(InternalLuaLibrary luaLibrary, string instanceId, string luaScriptInstanceId, IEventBus eventBus, IInternalEventFactory eventFactory)
+        public InternalLuaReference(string instanceId, string luaScriptInstanceId, IEventBus eventBus, IInternalEventFactory eventFactory)
         {
             InstanceId = instanceId;
             LuaScriptInstanceId = luaScriptInstanceId;
             EventBus = eventBus;
             EventFactory = eventFactory;
-            LuaLibrary = luaLibrary;
             Envelope = new EventEnvelope(luaScriptInstanceId).Add(instanceId);
-        }
-
-        public void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]

--- a/Components/Lua/Lua/InternalUtilLibrary.cs
+++ b/Components/Lua/Lua/InternalUtilLibrary.cs
@@ -33,9 +33,5 @@ namespace Slipstream.Components.Lua.Lua
                 new NamedParameter("luaLibrary", this)
             );
         }
-
-        public void ReferenceDropped(ILuaReference _)
-        {
-        }
     }
 }

--- a/Components/Lua/Lua/LuaInstanceThread.cs
+++ b/Components/Lua/Lua/LuaInstanceThread.cs
@@ -21,12 +21,12 @@ namespace Slipstream.Components.Lua.Lua
         private class Dependency
         {
             public string InstanceId { get; }
-            public string LuaScriptInstanceId { get;  }
+            public string LuaScriptInstanceId { get; }
 
             public Dependency(string instanceId, string luaScriptInstanceId)
             {
                 InstanceId = instanceId;
-                LuaScriptInstanceId = luaScriptInstanceId;  
+                LuaScriptInstanceId = luaScriptInstanceId;
             }
         }
 
@@ -38,7 +38,6 @@ namespace Slipstream.Components.Lua.Lua
         private readonly LuaLuaLibrary LuaLibrary;
         private readonly IEventBus EventBus;
         private readonly IInternalEventFactory InternalEventFactory;
-        private readonly List<ILuaReference> CreatedReferences = new List<ILuaReference>();
         private readonly IDictionary<string, DelayedExecution> DebounceDelayedFunctions = new Dictionary<string, DelayedExecution>();
         private readonly IDictionary<string, DelayedExecution> WaitDelayedFunctions = new Dictionary<string, DelayedExecution>();
         private readonly string FileName = "";
@@ -123,9 +122,6 @@ namespace Slipstream.Components.Lua.Lua
                 Logger.Error(e, "{fileName} errored: {message}", FileName, e.Message);
             }
 
-            Debug.WriteLine($"[{FileName}] Stopping. Clearning up {CreatedReferences.Count} references");
-            CreatedReferences.Clear();
-
             LuaLibrary.InstanceStopped(InstanceId);
 
             foreach (var dependency in Dependencies)
@@ -208,14 +204,12 @@ SS = {{
         {
             lock (Lock)
             {
-                CreatedReferences.Add(inst);
-
                 if (inst == null)
                     return;
 
                 var dependency = new Dependency(inst.InstanceId, inst.LuaScriptInstanceId);
 
-                if(!Dependencies.Contains(dependency))
+                if (!Dependencies.Contains(dependency))
                 {
                     Debug.WriteLine($"[{InstanceId}] depends on {inst.InstanceId}");
 

--- a/Components/Lua/Lua/LuaInstanceThread.cs
+++ b/Components/Lua/Lua/LuaInstanceThread.cs
@@ -128,7 +128,7 @@ namespace Slipstream.Components.Lua.Lua
             {
                 var envelope = new EventEnvelope(InstanceId).Add(dependency.InstanceId);
 
-                EventBus.PublishEvent(InternalEventFactory.CreateInternalInstanceRemoveSubscription(envelope, dependency.LuaScriptInstanceId));
+                EventBus.PublishEvent(InternalEventFactory.CreateInternalRemoveDependency(envelope, dependency.LuaScriptInstanceId));
             }
 
             Dependencies.Clear();
@@ -216,7 +216,7 @@ SS = {{
                     Dependencies.Add(dependency);
 
                     var envelope = new EventEnvelope(InstanceId).Add(dependency.InstanceId);
-                    EventBus.PublishEvent(InternalEventFactory.CreateInternalInstanceAddSubscription(envelope, InstanceId));
+                    EventBus.PublishEvent(InternalEventFactory.CreateInternalAddDependency(envelope, InstanceId));
                 }
             }
         }

--- a/Components/Lua/Lua/LuaLuaLibrary.cs
+++ b/Components/Lua/Lua/LuaLuaLibrary.cs
@@ -33,10 +33,6 @@ namespace Slipstream.Components.Lua.Lua
             EventBus = eventBus;
         }
 
-        internal void ReferenceDrop(LuaLuaReference _)
-        {
-        }
-
         public void Dispose()
         {
         }

--- a/Components/Lua/Lua/LuaLuaReference.cs
+++ b/Components/Lua/Lua/LuaLuaReference.cs
@@ -7,11 +7,9 @@ namespace Slipstream.Components.Lua.Lua
     public class LuaLuaReference : BaseLuaReference, ILuaLuaReference
     {
         private readonly ILuaInstanceThread ServiceThread;
-        private readonly LuaLuaLibrary LuaLibrary;
 
-        public LuaLuaReference(LuaLuaLibrary luaLibrary, string instanceId, string luaScriptInstanceId, ILuaInstanceThread serviceThread) : base(instanceId, luaScriptInstanceId)
+        public LuaLuaReference(string instanceId, string luaScriptInstanceId, ILuaInstanceThread serviceThread) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
             ServiceThread = serviceThread;
         }
 
@@ -28,11 +26,6 @@ namespace Slipstream.Components.Lua.Lua
         public void restart()
         {
             ServiceThread.Restart();
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDrop(this);
         }
 
         public void join()

--- a/Components/Lua/Lua/StateLuaLibrary.cs
+++ b/Components/Lua/Lua/StateLuaLibrary.cs
@@ -33,9 +33,5 @@ namespace Slipstream.Components.Lua.Lua
                 new NamedParameter("luaLibrary", this)
             );
         }
-
-        public void ReferenceDropped(ILuaReference _)
-        {
-        }
     }
 }

--- a/Components/Lua/Lua/StateLuaReference.cs
+++ b/Components/Lua/Lua/StateLuaReference.cs
@@ -8,21 +8,14 @@ namespace Slipstream.Components.Lua.Lua
     public class StateLuaReference : ILuaReference
     {
         private readonly IStateService StateService;
-        private readonly StateLuaLibrary LuaLibrary;
         public string InstanceId { get; }
         public string LuaScriptInstanceId { get; }
 
-        public StateLuaReference(StateLuaLibrary luaLibrary, string instanceId, string luaScriptInstanceId, IStateService stateService)
+        public StateLuaReference(string instanceId, string luaScriptInstanceId, IStateService stateService)
         {
-            LuaLibrary = luaLibrary;
             InstanceId = instanceId;
             LuaScriptInstanceId = luaScriptInstanceId;
             StateService = stateService;
-        }
-
-        public void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]

--- a/Components/Lua/Lua/UtilLuaLibrary.cs
+++ b/Components/Lua/Lua/UtilLuaLibrary.cs
@@ -33,9 +33,5 @@ namespace Slipstream.Components.Lua.Lua
                 new NamedParameter("luaLibrary", this)
             );
         }
-
-        public void ReferenceDropped(ILuaReference luaReference)
-        {
-        }
     }
 }

--- a/Components/Lua/Lua/UtilLuaReference.cs
+++ b/Components/Lua/Lua/UtilLuaReference.cs
@@ -15,22 +15,15 @@ namespace Slipstream.Components.Lua.Lua
     {
         private readonly IEventSerdeService EventSerdeService;
         private readonly ILogger Logger;
-        private readonly UtilLuaLibrary LuaLibrary;
         public string InstanceId { get; }
         public string LuaScriptInstanceId { get; }
 
-        public UtilLuaReference(string instanceId, string luaScriptInstanceId, UtilLuaLibrary luaLibrary, IEventSerdeService eventSerdeService, ILogger logger)
+        public UtilLuaReference(string instanceId, string luaScriptInstanceId, IEventSerdeService eventSerdeService, ILogger logger)
         {
             InstanceId = instanceId;
             LuaScriptInstanceId = luaScriptInstanceId;
-            LuaLibrary = luaLibrary;
             EventSerdeService = eventSerdeService;
             Logger = logger;
-        }
-
-        public void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]

--- a/Components/Playback/Lua/PlaybackLuaLibrary.cs
+++ b/Components/Playback/Lua/PlaybackLuaLibrary.cs
@@ -5,7 +5,6 @@ using Slipstream.Shared.Lua;
 using Slipstream.Shared.Helpers.StrongParameters;
 using Slipstream.Shared.Helpers.StrongParameters.Validators;
 using Slipstream.Shared;
-using Slipstream.Components.Internal;
 
 namespace Slipstream.Components.Playback.Lua
 {
@@ -19,7 +18,7 @@ namespace Slipstream.Components.Playback.Lua
                 .RequireString("id");
         }
 
-        public PlaybackLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public PlaybackLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/Playback/Lua/PlaybackLuaReference.cs
+++ b/Components/Playback/Lua/PlaybackLuaReference.cs
@@ -9,18 +9,11 @@ namespace Slipstream.Components.Playback.Lua
     {
         private readonly IEventBus EventBus;
         private readonly IPlaybackEventFactory EventFactory;
-        private readonly PlaybackLuaLibrary LuaLibrary;
 
-        public PlaybackLuaReference(string instanceId, string luaScriptInstanceId, PlaybackLuaLibrary luaLibrary, IEventBus eventBus, IPlaybackEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
+        public PlaybackLuaReference(string instanceId, string luaScriptInstanceId, IEventBus eventBus, IPlaybackEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
             EventBus = eventBus;
             EventFactory = eventFactory;
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]

--- a/Components/Twitch/Lua/TwitchLuaLibrary.cs
+++ b/Components/Twitch/Lua/TwitchLuaLibrary.cs
@@ -21,7 +21,7 @@ namespace Slipstream.Components.Twitch.Lua
                 .PermitBool("log");
         }
 
-        public TwitchLuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public TwitchLuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/Twitch/Lua/TwitchLuaReference.cs
+++ b/Components/Twitch/Lua/TwitchLuaReference.cs
@@ -7,23 +7,15 @@ namespace Slipstream.Components.Twitch.Lua
     {
         private readonly IEventBus EventBus;
         private readonly ITwitchEventFactory EventFactory;
-        private readonly TwitchLuaLibrary LuaLibrary;
 
         public TwitchLuaReference(
-            TwitchLuaLibrary luaLibrary,
             string instanceId,
             string luaScriptInstanceId,
             IEventBus eventBus,
             ITwitchEventFactory eventFactory) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
             EventBus = eventBus;
             EventFactory = eventFactory;
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]

--- a/Components/UI/Lua/IUILibraryReference.cs
+++ b/Components/UI/Lua/IUILibraryReference.cs
@@ -10,10 +10,8 @@ namespace Slipstream.Components.UI.Lua
         private readonly IUIEventFactory EventFactory;
         private readonly ILogger Logger;
         private readonly string Prefix;
-        private readonly UILuaLibrary LuaLibrary;
 
         public IUILibraryReference(
-            UILuaLibrary luaLibrary,
             string instanceId,
             string luaScriptInstanceId,
             string prefix,
@@ -21,7 +19,6 @@ namespace Slipstream.Components.UI.Lua
             IUIEventFactory eventFactory,
             ILogger logger) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
             EventBus = eventBus;
             EventFactory = eventFactory;
             Logger = logger;
@@ -44,11 +41,6 @@ namespace Slipstream.Components.UI.Lua
         public void delete_button(string text)
         {
             EventBus.PublishEvent(EventFactory.CreateUICommandDeleteButton(Envelope, text));
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
     }
 }

--- a/Components/UI/Lua/UILuaLibrary.cs
+++ b/Components/UI/Lua/UILuaLibrary.cs
@@ -46,9 +46,5 @@ namespace Slipstream.Components.UI.Lua
                 new NamedParameter("prefix", prefix)
             );
         }
-
-        public void ReferenceDropped(ILuaReference _)
-        {
-        }
     }
 }

--- a/Components/WinFormUI/Lua/WinFormUILuaLibrary.cs
+++ b/Components/WinFormUI/Lua/WinFormUILuaLibrary.cs
@@ -5,7 +5,6 @@ using Slipstream.Shared.Lua;
 using Slipstream.Shared.Helpers.StrongParameters;
 using Slipstream.Shared.Helpers.StrongParameters.Validators;
 using Slipstream.Shared;
-using Slipstream.Components.Internal;
 
 namespace Slipstream.Components.WinFormUI.Lua
 {
@@ -19,7 +18,7 @@ namespace Slipstream.Components.WinFormUI.Lua
                 .RequireString("id");
         }
 
-        public WinFormUILuaLibrary(ILifetimeScope scope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(ConfigurationValidator, scope, eventBus, eventFactory)
+        public WinFormUILuaLibrary(ILifetimeScope scope, IEventBus eventBus) : base(ConfigurationValidator, scope, eventBus)
         {
         }
 

--- a/Components/WinFormUI/Lua/WinFormUIReference.cs
+++ b/Components/WinFormUI/Lua/WinFormUIReference.cs
@@ -4,16 +4,8 @@ namespace Slipstream.Components.WinFormUI.Lua
 {
     public class WinFormUIReference : BaseLuaReference, IWinFormUIReference
     {
-        public WinFormUILuaLibrary LuaLibrary { get; }
-
-        public WinFormUIReference(string instanceId, string luaScriptInstanceId, WinFormUILuaLibrary luaLibrary) : base(instanceId, luaScriptInstanceId)
+        public WinFormUIReference(string instanceId, string luaScriptInstanceId) : base(instanceId, luaScriptInstanceId)
         {
-            LuaLibrary = luaLibrary;
-        }
-
-        public override void Dispose()
-        {
-            LuaLibrary.ReferenceDropped(this);
         }
     }
 }

--- a/Shared/Lua/BaseInstanceThread.cs
+++ b/Shared/Lua/BaseInstanceThread.cs
@@ -23,8 +23,8 @@ namespace Slipstream.Shared.Lua
             InstanceEnvelope = new EventEnvelope(instanceId);
 
             var internalHandler = eventHandlerController.Get<Internal>();
-            internalHandler.OnInternalInstanceAddSubscription += (_, e) => InstanceEnvelope = InstanceEnvelope.Add(e.InstanceId);
-            internalHandler.OnInternalInstanceRemoveSubscription += (_, e) => InstanceEnvelope = InstanceEnvelope.Remove(e.InstanceId);
+            internalHandler.OnInternaAddDependency += (_, e) => InstanceEnvelope = InstanceEnvelope.Add(e.InstanceId);
+            internalHandler.OnInternalRemoveDependency += (_, e) => InstanceEnvelope = InstanceEnvelope.Remove(e.InstanceId);
 
             SetupThread();
         }

--- a/Shared/Lua/BaseLuaLibrary.cs
+++ b/Shared/Lua/BaseLuaLibrary.cs
@@ -90,10 +90,7 @@ namespace Slipstream.Shared.Lua
                 var instance = CreateInstance(LifetimeScope, cfg);
                 Instances.Add(instanceId, new InstanceContainer<TInstance>(instance));
                 instance.Start();
-
             }
-            var envelope = new EventEnvelope(luaScriptInstanceId).Add(instanceId);
-            EventBus.PublishEvent(InternalEventFactory.CreateInternalInstanceAddSubscription(envelope, luaScriptInstanceId));
         }
 
         public void ReferenceDropped(ILuaReference luaReference)
@@ -119,10 +116,6 @@ namespace Slipstream.Shared.Lua
                 {
                     Debug.WriteLine($"***** ERROR - LuaReference '{instanceId}' points to an non-existing instance *****");
                 }
-
-                var envelope = new EventEnvelope(luaReference.LuaScriptInstanceId).Add(instanceId);
-
-                EventBus.PublishEvent(InternalEventFactory.CreateInternalInstanceRemoveSubscription(envelope, luaReference.LuaScriptInstanceId));
             }
         }
     }

--- a/Shared/Lua/BaseLuaReference.cs
+++ b/Shared/Lua/BaseLuaReference.cs
@@ -8,7 +8,6 @@ namespace Slipstream.Shared.Lua
 
         public string InstanceId { get; }
         public string LuaScriptInstanceId { get; }
-        public abstract void Dispose();
 
         public BaseLuaReference(string instanceId, string luaScriptInstanceId)
         {

--- a/Shared/Lua/ILuaReference.cs
+++ b/Shared/Lua/ILuaReference.cs
@@ -4,7 +4,7 @@ using System;
 
 namespace Slipstream.Shared.Lua
 {
-    public interface ILuaReference : IDisposable
+    public interface ILuaReference
     {
         public string InstanceId { get; }
         public string LuaScriptInstanceId { get; }

--- a/Shared/Lua/SingletonLuaLibrary.cs
+++ b/Shared/Lua/SingletonLuaLibrary.cs
@@ -1,7 +1,6 @@
 ﻿#nullable enable
 
 using Autofac;
-using Slipstream.Components.Internal;
 using Slipstream.Shared.Helpers.StrongParameters;
 using Slipstream.Shared.Helpers.StrongParameters.Validators;
 
@@ -11,16 +10,16 @@ namespace Slipstream.Shared.Lua
         where TInstance : ILuaInstanceThread
         where TReference : ILuaReference
     {
-        protected SingletonLuaLibrary(DictionaryValidator validator, ILifetimeScope lifetimeScope, IEventBus eventBus, IInternalEventFactory eventFactory) : base(validator, lifetimeScope, eventBus, eventFactory)
+        protected SingletonLuaLibrary(DictionaryValidator validator, ILifetimeScope lifetimeScope, IEventBus eventBus) : base(validator, lifetimeScope, eventBus)
         {
         }
 
-        new protected void HandleInstance(string luaScriptInstanceId, string _, Parameters cfg)
+        new protected void HandleInstance(string _, Parameters cfg)
         {
             // Force instanceId to be "singleton", so we never get more than one
             cfg["instanceId"] = "singleton";
 
-            base.HandleInstance(luaScriptInstanceId, "singleton", cfg);
+            base.HandleInstance("singleton", cfg);
         }
     }
 }

--- a/Slipstream.csproj
+++ b/Slipstream.csproj
@@ -194,8 +194,8 @@
     <Compile Include="Components\AppilcationUpdate\Lua\ApplicationUpdateLuaLibrary.cs" />
     <Compile Include="Components\AppilcationUpdate\Lua\ApplicationUpdateReference.cs" />
     <Compile Include="Shared\Lua\BaseLuaReference.cs" />
-    <Compile Include="Components\Internal\Events\InternalInstanceAddSubscription.cs" />
-    <Compile Include="Components\Internal\Events\InternalInstanceRemoveSubscription.cs" />
+    <Compile Include="Components\Internal\Events\InternalAddDependency.cs" />
+    <Compile Include="Components\Internal\Events\InternalRemoveDependency.cs" />
     <Compile Include="Components\IRacing\Events\IRacingCommandPitChangeLeftRearTyre.cs" />
     <Compile Include="Components\IRacing\Events\IRacingCommandPitRequestFastRepair.cs" />
     <Compile Include="Components\IRacing\Events\IRacingCommandPitClearTyresChange.cs" />


### PR DESCRIPTION
Initially, I was using LuaReferences (the objects that Slipstream handles to the Lua code) to keep track of usage. So if all references to a certain Instance were freed, it would stop the instance. And starting it again, if needed, when new ones were created.

This didnt really worked that well, as for some reason, NLua kept it's reference to the Reference object longer than expected.

This PR simplifies how this work:
1) We're are not shutting instances down when not used. it can be implemented as each instance know how many is using it.
2) Instead of tracking LuaReferences, each Lua script sends a `InternalAddDependency` when a new instance is used, and upon exit it will send a `InternalRemoveDependency`. 

