### PR TITLE
Fixes twich shutdown

### DIFF
--- a/Components/Twitch/Lua/TwitchLuaInstanceThread.cs
+++ b/Components/Twitch/Lua/TwitchLuaInstanceThread.cs
@@ -72,17 +72,17 @@ namespace Slipstream.Components.Twitch.Lua
             {
                 IEvent? @event = Subscription.NextEvent(100);
 
+                if (@event != null)
+                {
+                    EventHandlerController.HandleEvent(@event);
+                }
+
                 if (RequestReconnect)
                 {
                     Disconnect();
                     Connect();
 
                     RequestReconnect = false;
-                }
-
-                if (@event != null)
-                {
-                    EventHandlerController.HandleEvent(@event);
                 }
             }
         }
@@ -270,7 +270,7 @@ namespace Slipstream.Components.Twitch.Lua
         private void OnDisconnect(object sender, OnDisconnectedEventArgs e)
         {
             AnnounceDisconnected();
-            RequestReconnect = true;
+            RequestReconnect = !Stopping;
         }
 
         private void OnError(object sender, OnErrorEventArgs e)

--- a/Shared/Lua/BaseInstanceThread.cs
+++ b/Shared/Lua/BaseInstanceThread.cs
@@ -23,6 +23,7 @@ namespace Slipstream.Shared.Lua
             InstanceEnvelope = new EventEnvelope(instanceId);
 
             var internalHandler = eventHandlerController.Get<Internal>();
+            internalHandler.OnInternalCommandShutdown += (_, e) => Stopping = true;
             internalHandler.OnInternaAddDependency += (_, e) => InstanceEnvelope = InstanceEnvelope.Add(e.InstanceId);
             internalHandler.OnInternalRemoveDependency += (_, e) => InstanceEnvelope = InstanceEnvelope.Remove(e.InstanceId);
 
@@ -52,6 +53,8 @@ namespace Slipstream.Shared.Lua
 
             if (AutoStart)
             {
+                Logger.Debug($"Autostarting {GetType().Name } {InstanceId}");
+
                 AutoStart = false;
                 Stopping = false;
                 ThreadMain();


### PR DESCRIPTION
It would try to reconnect, as it reacted to the
OnDisconect() event and would always try to
reconnect, which it sometimes did, before
slipstream was finish shutting down.

Now it is aware of Shutdown event and will
only reconnect if we're not shutting down.