### PR TITLE
Bugfix: IRacingThread crash.

### DIFF
--- a/Components/IRacing/Trackers/Trackers.cs
+++ b/Components/IRacing/Trackers/Trackers.cs
@@ -1,4 +1,6 @@
-﻿using Slipstream.Components.IRacing.Models;
+﻿#nullable enable
+
+using Slipstream.Components.IRacing.Models;
 using Slipstream.Shared;
 using System.Collections.Generic;
 using static Slipstream.Components.IRacing.Trackers.IIRacingDataTracker;
@@ -34,8 +36,11 @@ namespace Slipstream.Components.IRacing.Trackers
                 t.Handle(currentState, TrackerState, envelope);
         }
 
-        public void Request(GameState.IState currentState, IEventEnvelope envelope, RequestType type)
+        public void Request(GameState.IState? currentState, IEventEnvelope envelope, RequestType type)
         {
+            if (currentState == null)
+                return;
+
             foreach (var t in DataTrackers)
                 t.Request(currentState, TrackerState, envelope, type);
         }


### PR DESCRIPTION
If IRacing isn't running, but you send a:
IRacingCommandSendCarInfo / SendTrackInfo / SendTrackInfo / WeatherInfo / SessionState / SendRaceFlags event, it would cause IRacingThead
to crash.