### PR TITLE
Fix instances would not restart even if requested

### DIFF
--- a/Components/WebWidget/HttpServer.cs
+++ b/Components/WebWidget/HttpServer.cs
@@ -191,5 +191,10 @@ namespace Slipstream.Components.WebWidget
         public void Dispose()
         {
         }
+
+        public bool ContainsInstance(string instanceId)
+        {
+            return Instances.TryGetValue(instanceId, out _);
+        }
     }
 }

--- a/Components/WebWidget/IHttpServerApi.cs
+++ b/Components/WebWidget/IHttpServerApi.cs
@@ -6,6 +6,9 @@ namespace Slipstream.Components.WebWidget
     {
         // These needs to be threadsafe!
         void AddInstance(string instanceId, string instanceType, string? data);
+
         void RemoveInstance(string instanceId);
+
+        bool ContainsInstance(string instanceId);
     }
 }

--- a/Components/WebWidget/IWebWidgetInstances.cs
+++ b/Components/WebWidget/IWebWidgetInstances.cs
@@ -32,6 +32,8 @@ namespace Slipstream.Components.WebWidget
 
         void Remove(string id);
 
+        bool Contains(string id);
+
         Instance this[string id] { get; }
 
         bool TryGetValue(string instanceId, out Instance result);

--- a/Components/WebWidget/Lua/WebWidgetInstanceThread.cs
+++ b/Components/WebWidget/Lua/WebWidgetInstanceThread.cs
@@ -11,6 +11,8 @@ namespace Slipstream.Components.WebWidget.Lua
         private readonly IHttpServerApi HttpServer;
         private readonly string? Data;
 
+        public bool Stopped => HttpServer.ContainsInstance(InstanceId);
+
         public WebWidgetInstanceThread(string instanceId, string webWidgetType, string data, IHttpServerApi httpServer)
         {
             InstanceId = instanceId;

--- a/Components/WebWidget/WebWidgetInstances.cs
+++ b/Components/WebWidget/WebWidgetInstances.cs
@@ -65,5 +65,11 @@ namespace Slipstream.Components.WebWidget
             lock (Instances)
                 return Instances.Keys;
         }
+
+        public bool Contains(string id)
+        {
+            lock (Instances)
+                return Instances.ContainsKey(id);
+        }
     }
 }

--- a/Shared/Lua/BaseInstanceThread.cs
+++ b/Shared/Lua/BaseInstanceThread.cs
@@ -22,6 +22,7 @@ namespace Slipstream.Shared.Lua
         protected IEventBus EventBus;
         protected readonly string LuaLibraryName;
         protected IInternalEventFactory InternalEventFactory;
+        public bool Stopped { get; internal set; }
 
         protected BaseInstanceThread(
             string luaLLibraryName,
@@ -39,6 +40,7 @@ namespace Slipstream.Shared.Lua
             LuaLibraryName = luaLLibraryName;
             EventBus = eventBus;
             InternalEventFactory = internalEventFactory;
+            Stopped = false;
 
             var internalHandler = eventHandlerController.Get<Internal>();
             internalHandler.OnInternalCommandShutdown += (_, e) => Stopping = true;
@@ -100,6 +102,7 @@ namespace Slipstream.Shared.Lua
             }
 
             EventBus.PublishEvent(InternalEventFactory.CreateInternalInstanceRemoved(BroadcastEnvelope, LuaLibraryName, InstanceId));
+            Stopped = true;
         }
 
         protected abstract void Main();
@@ -119,6 +122,10 @@ namespace Slipstream.Shared.Lua
                 SetupThread();
                 ServiceThread.Start();
                 EventBus.PublishEvent(InternalEventFactory.CreateInternalInstanceAdded(BroadcastEnvelope, LuaLibraryName, InstanceId));
+            }
+            else
+            {
+                throw new Exception(ServiceThread?.ThreadState.ToString());
             }
         }
 

--- a/Shared/Lua/BaseLuaLibrary.cs
+++ b/Shared/Lua/BaseLuaLibrary.cs
@@ -72,13 +72,23 @@ namespace Slipstream.Shared.Lua
 
         protected virtual void HandleInstance(string luaScriptInstanceId, string instanceId, Parameters cfg)
         {
+            // Remove instance if it is stopped meanwhile
+            if (Instances.TryGetValue(instanceId, out TInstance instance))
+            {
+                if (instance.Stopped)
+                {
+                    Instances.Remove(instanceId);
+                    instance.Dispose();
+                }
+            }
+
             if (!Instances.ContainsKey(instanceId))
             {
                 Debug.WriteLine($"[{instanceId}] Creating instance {GetType().Name}");
 
-                var instance = CreateInstance(LifetimeScope, luaScriptInstanceId, cfg);
-                Instances.Add(instanceId, instance);
-                instance.Start();
+                var newInstance = CreateInstance(LifetimeScope, luaScriptInstanceId, cfg);
+                Instances.Add(instanceId, newInstance);
+                newInstance.Start();
             }
         }
 

--- a/Shared/Lua/ILuaInstanceThread.cs
+++ b/Shared/Lua/ILuaInstanceThread.cs
@@ -6,6 +6,8 @@ namespace Slipstream.Shared.Lua
 {
     public interface ILuaInstanceThread : IDisposable
     {
+        bool Stopped { get; }
+
         void Start();
 
         void Stop();

--- a/Shared/Lua/NoopInstanceThread.cs
+++ b/Shared/Lua/NoopInstanceThread.cs
@@ -13,6 +13,7 @@ namespace Slipstream.Shared.Lua
         private readonly string LuaLibraryName;
         private readonly string InstanceId;
         private readonly IEventEnvelope Envelope;
+        public bool Stopped => false;
 
         public NoopInstanceThread(string luaLibraryName, string instanceId, IEventBus eventBus, IInternalEventFactory internalEventFactory)
         {


### PR DESCRIPTION
If an instance would have no dependencies and decides
to shut down, Slipstream would never be able to start it
again.