### PR TITLE
Bugfix: Events shared timestamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
    is removed (eg. script deleted or reloaded)
  - Bugfix: Clear delayed functions (debounce and wait) on script restart
  - WebWidget: Allow javascript to send `WebWidgetData` via js function `sendData(data)`
+ - Bugfix: Events seems to be were out of order judging by their timestamp
 
 ## [0.9.0](https://github.com/dennis/slipstream/releases/tag/v0.9.0) (2021-08-21)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.8.0...v0.9.0)

--- a/Components/AppilcationUpdate/EventFactory/ApplicationUpdateEventFactory.cs
+++ b/Components/AppilcationUpdate/EventFactory/ApplicationUpdateEventFactory.cs
@@ -7,14 +7,14 @@ namespace Slipstream.Components.AppilcationUpdate.EventFactory
     {
         public ApplicationUpdateCommandCheckLatestVersion CreateApplicationUpdateCommandCheckLatestVersion(IEventEnvelope envelope)
         {
-            return new ApplicationUpdateCommandCheckLatestVersion { Envelope = envelope };
+            return new ApplicationUpdateCommandCheckLatestVersion { Envelope = envelope.Clone() };
         }
 
         public ApplicationUpdateLatestVersionChanged CreateApplicationUpdateLatestVersionChanged(IEventEnvelope envelope, string version)
         {
             return new ApplicationUpdateLatestVersionChanged
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 LatestVersion = version,
             };
         }

--- a/Components/Audio/EventFactory/AudioEventFactory.cs
+++ b/Components/Audio/EventFactory/AudioEventFactory.cs
@@ -9,27 +9,27 @@ namespace Slipstream.Components.Audio.EventFactory
     {
         public AudioCommandPlay CreateAudioCommandPlay(IEventEnvelope envelope, string filename, float volume)
         {
-            return new AudioCommandPlay { Envelope = envelope, Filename = filename, Volume = volume };
+            return new AudioCommandPlay { Envelope = envelope.Clone(), Filename = filename, Volume = volume };
         }
 
         public AudioCommandSay CreateAudioCommandSay(IEventEnvelope envelope, string message, float volume)
         {
-            return new AudioCommandSay { Envelope = envelope, Message = message, Volume = volume };
+            return new AudioCommandSay { Envelope = envelope.Clone(), Message = message, Volume = volume };
         }
 
         public AudioCommandSendDevices CreateAudioCommandSendDevices(IEventEnvelope envelope)
         {
-            return new AudioCommandSendDevices { Envelope = envelope };
+            return new AudioCommandSendDevices { Envelope = envelope.Clone() };
         }
 
         public AudioOutputDevice CreateAudioOutputDevice(IEventEnvelope envelope, string product, int deviceIdx)
         {
-            return new AudioOutputDevice { DeviceIdx = deviceIdx, Envelope = envelope, Product = product };
+            return new AudioOutputDevice { DeviceIdx = deviceIdx, Envelope = envelope.Clone(), Product = product };
         }
 
         public AudioCommandSetOutputDevice CreateAudioCommandSetOutputDevice(IEventEnvelope envelope, int deviceIdx)
         {
-            return new AudioCommandSetOutputDevice { Envelope = envelope, DeviceIdx = deviceIdx };
+            return new AudioCommandSetOutputDevice { Envelope = envelope.Clone(), DeviceIdx = deviceIdx };
         }
     }
 }

--- a/Components/Discord/EventFactory/DiscordEventFactory.cs
+++ b/Components/Discord/EventFactory/DiscordEventFactory.cs
@@ -9,7 +9,7 @@ namespace Slipstream.Components.Discord.EventFactory
         {
             return new DiscordCommandSendMessage
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 ChannelId = channelId,
                 Message = message,
                 TextToSpeech = tts
@@ -20,7 +20,7 @@ namespace Slipstream.Components.Discord.EventFactory
         {
             return new DiscordConnected
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
             };
         }
 
@@ -28,7 +28,7 @@ namespace Slipstream.Components.Discord.EventFactory
         {
             return new DiscordDisconnected
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
             };
         }
 
@@ -36,7 +36,7 @@ namespace Slipstream.Components.Discord.EventFactory
         {
             return new DiscordMessageReceived
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 FromId = fromId,
                 From = from,
                 ChannelId = channelId,

--- a/Components/FileMonitor/EventFactory/FileMonitorEventFactory.cs
+++ b/Components/FileMonitor/EventFactory/FileMonitorEventFactory.cs
@@ -9,32 +9,32 @@ namespace Slipstream.Components.FileMonitor.EventFactory
     {
         public FileMonitorFileChanged CreateFileMonitorFileChanged(IEventEnvelope envelope, string filePath)
         {
-            return new FileMonitorFileChanged { Envelope = envelope, FilePath = filePath };
+            return new FileMonitorFileChanged { Envelope = envelope.Clone(), FilePath = filePath };
         }
 
         public FileMonitorFileCreated CreateFileMonitorFileCreated(IEventEnvelope envelope, string path)
         {
-            return new FileMonitorFileCreated { Envelope = envelope, FilePath = path };
+            return new FileMonitorFileCreated { Envelope = envelope.Clone(), FilePath = path };
         }
 
         public FileMonitorFileDeleted CreateFileMonitorFileDeleted(IEventEnvelope envelope, string filePath)
         {
-            return new FileMonitorFileDeleted { Envelope = envelope, FilePath = filePath };
+            return new FileMonitorFileDeleted { Envelope = envelope.Clone(), FilePath = filePath };
         }
 
         public FileMonitorFileRenamed CreateFileMonitorFileRenamed(IEventEnvelope envelope, string filePath, string oldFilePath)
         {
-            return new FileMonitorFileRenamed { Envelope = envelope, FilePath = filePath, OldFilePath = oldFilePath };
+            return new FileMonitorFileRenamed { Envelope = envelope.Clone(), FilePath = filePath, OldFilePath = oldFilePath };
         }
 
         public FileMonitorCommandScan CreateFileMonitorCommandScan(IEventEnvelope envelope)
         {
-            return new FileMonitorCommandScan { Envelope = envelope };
+            return new FileMonitorCommandScan { Envelope = envelope.Clone() };
         }
 
         public FileMonitorScanCompleted CreateFileMonitorScanCompleted(IEventEnvelope envelope)
         {
-            return new FileMonitorScanCompleted { Envelope = envelope };
+            return new FileMonitorScanCompleted { Envelope = envelope.Clone() };
         }
     }
 }

--- a/Components/IRacing/EventFactory/IRacingEventFactory.cs
+++ b/Components/IRacing/EventFactory/IRacingEventFactory.cs
@@ -1,7 +1,9 @@
 ﻿using Slipstream.Components.IRacing.Events;
 using Slipstream.Components.IRacing.GameState;
 using Slipstream.Shared;
+
 using System;
+
 using static Slipstream.Components.IRacing.IIRacingEventFactory;
 
 #nullable enable
@@ -25,7 +27,7 @@ namespace Slipstream.Components.IRacing.EventFactory
         {
             return new IRacingCompletedLap
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 SessionTime = sessionTime,
                 CarIdx = carIdx,
                 LapTime = lapTime,
@@ -56,7 +58,7 @@ namespace Slipstream.Components.IRacing.EventFactory
         {
             return new IRacingCarInfo
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 SessionTime = sessionTime,
                 CarIdx = carIdx,
                 CarNumber = carNumber,
@@ -77,7 +79,7 @@ namespace Slipstream.Components.IRacing.EventFactory
         {
             return new IRacingConnected
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
             };
         }
 
@@ -110,14 +112,14 @@ namespace Slipstream.Components.IRacing.EventFactory
 
         public IRacingDisconnected CreateIRacingDisconnected(IEventEnvelope envelope)
         {
-            return new IRacingDisconnected { Envelope = envelope };
+            return new IRacingDisconnected { Envelope = envelope.Clone() };
         }
 
         public IRacingPitEnter CreateIRacingPitEnter(IEventEnvelope envelope, double sessionTime, long carIdx, bool localUser)
         {
             return new IRacingPitEnter
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 SessionTime = sessionTime,
                 CarIdx = carIdx,
                 LocalUser = localUser

--- a/Components/Internal/EventFactory/InternalEventFactory.cs
+++ b/Components/Internal/EventFactory/InternalEventFactory.cs
@@ -9,14 +9,14 @@ namespace Slipstream.Components.Internal.EventFactory
     {
         public InternalCommandShutdown CreateInternalCommandShutdown(IEventEnvelope envelope)
         {
-            return new InternalCommandShutdown { Envelope = envelope };
+            return new InternalCommandShutdown { Envelope = envelope.Clone() };
         }
 
         public InternalDependencyAdded CreateInternalDependencyAdded(IEventEnvelope envelope, string luaLibrary, string instanceId, string dependsOn)
         {
             return new InternalDependencyAdded
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 LuaLibrary = luaLibrary,
                 InstanceId = instanceId,
                 DependsOn = dependsOn,
@@ -27,7 +27,7 @@ namespace Slipstream.Components.Internal.EventFactory
         {
             return new InternalDependencyRemoved
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 LuaLibrary = luaLibrary,
                 InstanceId = instanceId,
                 DependsOn = dependsOn,
@@ -38,7 +38,7 @@ namespace Slipstream.Components.Internal.EventFactory
         {
             return new InternalInstanceAdded
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 LuaLibrary = luaLibrary,
                 InstanceId = instanceId
             };
@@ -48,7 +48,7 @@ namespace Slipstream.Components.Internal.EventFactory
         {
             return new InternalInstanceRemoved
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 LuaLibrary = luaLibrary,
                 InstanceId = instanceId
             };

--- a/Components/Lua/EventFactory/LuaEventFactory.cs
+++ b/Components/Lua/EventFactory/LuaEventFactory.cs
@@ -26,7 +26,7 @@ namespace Slipstream.Components.Lua.EventFactory
 
             return new LuaCommandDeduplicateEvents
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Events = json
             };
         }

--- a/Components/Playback/EventFactory/PlaybackEventFactory.cs
+++ b/Components/Playback/EventFactory/PlaybackEventFactory.cs
@@ -11,7 +11,7 @@ namespace Slipstream.Components.Playback.EventFactory
         {
             return new PlaybackCommandInjectEvents
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Filename = filename
             };
         }
@@ -20,7 +20,7 @@ namespace Slipstream.Components.Playback.EventFactory
         {
             return new PlaybackCommandSaveEvents
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Filename = filename
             };
         }

--- a/Components/Twitch/EventFactory/TwitchEventFactory.cs
+++ b/Components/Twitch/EventFactory/TwitchEventFactory.cs
@@ -11,26 +11,26 @@ namespace Slipstream.Components.Twitch.EventFactory
         {
             return new TwitchCommandSendMessage
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Message = message
             };
         }
 
         public TwitchConnected CreateTwitchConnected(IEventEnvelope envelope)
         {
-            return new TwitchConnected { Envelope = envelope };
+            return new TwitchConnected { Envelope = envelope.Clone() };
         }
 
         public TwitchDisconnected CreateTwitchDisconnected(IEventEnvelope envelope)
         {
-            return new TwitchDisconnected { Envelope = envelope };
+            return new TwitchDisconnected { Envelope = envelope.Clone() };
         }
 
         public TwitchReceivedMessage CreateTwitchReceivedMessage(IEventEnvelope envelope, string from, string message, bool moderator, bool subscriber, bool vip, bool broadcaster)
         {
             return new TwitchReceivedMessage
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 From = from,
                 Message = message,
                 Moderator = moderator,
@@ -44,7 +44,7 @@ namespace Slipstream.Components.Twitch.EventFactory
         {
             return new TwitchReceivedWhisper
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 From = from,
                 Message = message
             };
@@ -54,7 +54,7 @@ namespace Slipstream.Components.Twitch.EventFactory
         {
             return new TwitchCommandSendWhisper
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 To = to,
                 Message = message
             };
@@ -64,7 +64,7 @@ namespace Slipstream.Components.Twitch.EventFactory
         {
             return new TwitchUserSubscribed
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Name = name,
                 Message = message,
                 SystemMessage = systemMessage,
@@ -78,7 +78,7 @@ namespace Slipstream.Components.Twitch.EventFactory
         {
             return new TwitchGiftedSubscription
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Gifter = gifter,
                 SubscriptionPlan = subscriptionPlan,
                 Recipient = recipient,
@@ -90,7 +90,7 @@ namespace Slipstream.Components.Twitch.EventFactory
         {
             return new TwitchRaided
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Name = name,
                 ViewerCount = viewerCount,
             };

--- a/Components/WebWidget/EventFactory/WebWidgetEventFactory.cs
+++ b/Components/WebWidget/EventFactory/WebWidgetEventFactory.cs
@@ -10,22 +10,22 @@ namespace Slipstream.Components.Internal.EventFactory
     {
         public WebWidgetCommandEvent CreateWebWidgetCommandEvent(IEventEnvelope envelope, string data)
         {
-            return new WebWidgetCommandEvent { Envelope = envelope, Data = data };
+            return new WebWidgetCommandEvent { Envelope = envelope.Clone(), Data = data };
         }
 
         public WebWidgetEndpointAdded CreateWebWidgetEndpointAdded(IEventEnvelope envelope, string endpoint)
         {
-            return new WebWidgetEndpointAdded { Envelope = envelope, Endpoint = endpoint };
+            return new WebWidgetEndpointAdded { Envelope = envelope.Clone(), Endpoint = endpoint };
         }
 
         public WebWidgetEndpointRemoved CreateWebWidgetEndpointRemoved(IEventEnvelope envelope, string endpoint)
         {
-            return new WebWidgetEndpointRemoved { Envelope = envelope, Endpoint = endpoint };
+            return new WebWidgetEndpointRemoved { Envelope = envelope.Clone(), Endpoint = endpoint };
         }
 
         public WebWidgetData CreateWebWidgetData(IEventEnvelope envelope, string data)
         {
-            return new WebWidgetData { Envelope = envelope, Data = data };
+            return new WebWidgetData { Envelope = envelope.Clone(), Data = data };
         }
     }
 }

--- a/Components/WinFormUI/EventFactory/WinFormUIEventFactory.cs
+++ b/Components/WinFormUI/EventFactory/WinFormUIEventFactory.cs
@@ -11,7 +11,7 @@ namespace Slipstream.Components.WinFormUI.EventFactory
         {
             return new WinFormUICommandWriteToConsole
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Message = message,
                 Error = error
             };
@@ -21,7 +21,7 @@ namespace Slipstream.Components.WinFormUI.EventFactory
         {
             return new WinFormUICommandCreateButton
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Text = text,
             };
         }
@@ -30,7 +30,7 @@ namespace Slipstream.Components.WinFormUI.EventFactory
         {
             return new WinFormUICommandDeleteButton
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Text = text,
             };
         }
@@ -39,7 +39,7 @@ namespace Slipstream.Components.WinFormUI.EventFactory
         {
             return new WinFormUIButtonTriggered
             {
-                Envelope = envelope,
+                Envelope = envelope.Clone(),
                 Text = text
             };
         }

--- a/Shared/EventEnvelope.cs
+++ b/Shared/EventEnvelope.cs
@@ -88,5 +88,23 @@ namespace Slipstream.Shared
                 return true;
             }
         }
+
+        public IEventEnvelope Clone()
+        {
+            var recipients = new List<string>();
+
+            if (Recipients != null)
+            {
+                foreach (var r in Recipients)
+                {
+                    recipients.Add(r);
+                }
+            }
+
+            return new EventEnvelope(Sender)
+            {
+                Recipients = recipients.ToArray()
+            };
+        }
     }
 }

--- a/Shared/IEventEnvelope.cs
+++ b/Shared/IEventEnvelope.cs
@@ -10,10 +10,14 @@ namespace Slipstream.Shared
         string[]? Recipients { get; set; }
         UInt64 Uptime { get; set; }
 
-
         IEventEnvelope Reply(string instanceId);
+
         IEventEnvelope Add(string instanceId);
+
         IEventEnvelope Remove(string instanceId);
+
         bool ContainsRecipient(string instanceId);
+
+        IEventEnvelope Clone();
     }
 }


### PR DESCRIPTION
The timestamp `uptime` is updated when you publish an event. As we only
create a new envelope everytime we changed/add recipients, multiple
events would share the same envelope. This isn't a problem, unless you
consider the envelope also contains the timestamp. So suddenly all
events sharing the same envelope would have the timestamp of the last
event using that envelope.

When viewing the events they would seem out of order.