### PR TITLE
WinFormUI wouldn't always pick up creation events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@
    Use `parse_json(event.Json)` to get a LuaTable with the values as were sent 
    via the event. Also adds `generate_json(luaTable)` to generate json string from 
    a Lua table.
+ - Bugfix: WinFormUI wouldn't always pick up creation events, while it was initializing it's window.
 
 
 ## [0.9.0](https://github.com/dennis/slipstream/releases/tag/v0.9.0) (2021-08-21)

--- a/Components/WinFormUI/Forms/MainWindow.cs
+++ b/Components/WinFormUI/Forms/MainWindow.cs
@@ -56,6 +56,7 @@ namespace Slipstream.Components.WinFormUI.Forms
             IApplicationVersionService applicationVersionService,
             IEventHandlerController eventHandlerController,
             IEventSerdeService eventSerdeService,
+            IEventBusSubscription subscription,
             bool deepView
             )
         {
@@ -70,6 +71,8 @@ namespace Slipstream.Components.WinFormUI.Forms
             Envelope = new EventEnvelope(instanceId);
             BroadcastEnvelope = new EventEnvelope(instanceId);
             DeepView = deepView;
+
+            EventBusSubscription = subscription;
 
             InitializeComponent();
 
@@ -138,7 +141,6 @@ namespace Slipstream.Components.WinFormUI.Forms
 
         private void MainWindow_Load(object? sender, EventArgs e)
         {
-            EventBusSubscription = EventBus.RegisterListener(InstanceId, fromBeginning: true, promiscuousMode: true);
             EventHandlerThreadCancellationToken = EventHandlerThreadCts.Token;
             EventHandlerThread = new Thread(new ThreadStart(EventListenerMain))
             {

--- a/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
+++ b/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
@@ -45,6 +45,8 @@ namespace Slipstream.Components.WinFormUI.Lua
         [STAThreadAttribute]
         protected override void Main()
         {
+            var subscription = EventBus.RegisterListener(InstanceId, fromBeginning: true, promiscuousMode: true);
+
             Application.Run(new MainWindow(
                 InstanceId,
                 this,
@@ -55,6 +57,7 @@ namespace Slipstream.Components.WinFormUI.Lua
                 ApplicationVersionService,
                 EventHandlerController,
                 EventSerdeService,
+                subscription,
                 DeepView
            ));
         }


### PR DESCRIPTION
This would happen while it was creating the UI. To get around this, the
subscription is created before initializing UI, so at least the events
are queued until it's ready to process them