### PR TITLE
Don't exit WinFormUI if inactive

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
  - WinFormUI/EventViewer: Show custom events colored green and use their name instead of 
    InternalCustomEvent
  - WinFormUI/EventViewer: Show internal events colored gray.
+ - Don't exit WinFormUI if inactive (nothing depends on it). Once we start the UI, we expect 
+   it to be running until user exits
 
 ## [0.10.0](https://github.com/dennis/slipstream/releases/tag/v0.10.0) (2021-10-07)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.9.0...v0.10.0)

--- a/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
+++ b/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
@@ -62,6 +62,12 @@ namespace Slipstream.Components.WinFormUI.Lua
            ));
         }
 
+        protected override void InactiveInstance()
+        {
+            // Even if nothing depends on WinFormUI, we don't want to shut down once we're running
+            // That will make it really hard to debug problems as the events and console isn't visible
+        }
+
         // Expose Protected variable for MainWindow to see and react on
         internal bool IsStopping()
         {


### PR DESCRIPTION
This will make it hard to see console or events
in case its a mistake its closing. Once we start
the UI, we expect it to be running until user
exits