### PR TITLE
Dont terminate inactive instances immediately

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@
  - New component: JustGiving - monitor fundraisings and get events at new donations
  - WinFormUI: Console lines are now timestamped
  - WebWidgets: HTTP Server now listens on all IPs
+ - Core: When Lua scripts stop using a instance, then wait for a bit before shutting it down.
 
 ## [0.10.0](https://github.com/dennis/slipstream/releases/tag/v0.10.0) (2021-10-07)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.9.0...v0.10.0)

--- a/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
+++ b/Components/WinFormUI/Lua/WinFormUIInstanceThread.cs
@@ -62,7 +62,7 @@ namespace Slipstream.Components.WinFormUI.Lua
            ));
         }
 
-        protected override void InactiveInstance()
+        protected override void InactiveInstance(ulong uptime)
         {
             // Even if nothing depends on WinFormUI, we don't want to shut down once we're running
             // That will make it really hard to debug problems as the events and console isn't visible

--- a/Shared/EventHandlerController.cs
+++ b/Shared/EventHandlerController.cs
@@ -1,5 +1,7 @@
 ﻿using Autofac;
+
 using Slipstream.Backend;
+
 using System;
 using System.Collections.Generic;
 
@@ -12,9 +14,13 @@ namespace Slipstream.Shared
         private readonly IDictionary<dynamic, IEventHandler> Handlers = new Dictionary<dynamic, IEventHandler>();
 
         private volatile bool enabled = true;
-        public bool Enabled { get { return enabled; } set { enabled = value; } }
+
+        public bool Enabled
+        { get { return enabled; } set { enabled = value; } }
 
         public event EventHandler<IEvent>? OnDefault;
+
+        public event EventHandler<IEvent>? OnAllways;
 
         public EventHandlerController(ILifetimeScope scope)
         {
@@ -41,6 +47,8 @@ namespace Slipstream.Shared
         {
             if (ev == null || !Enabled)
                 return;
+
+            OnAllways?.Invoke(this, ev);
 
             bool handled = false;
 

--- a/Shared/IEventHandlerController.cs
+++ b/Shared/IEventHandlerController.cs
@@ -10,6 +10,8 @@ namespace Slipstream.Shared
 
         public event EventHandler<IEvent>? OnDefault;
 
+        public event EventHandler<IEvent>? OnAllways;
+
         public T Get<T>();
 
         public void HandleEvent(IEvent? ev);


### PR DESCRIPTION
Reloading script triggered a problem, that this hopefully will fix: When
a lua script is reloaded its removed + loaded. When removing the script
it sends out InternalDependencyRemoved and if one or more instance isn't
used it will shut down. However if the instance didnt process that event
yet (so still running, but soon will stop) and the new script checks if
the instance is available (which it is) and a moment later the instance
would process the event and shut down, leaving the script with a missing
instance - aka it would be broken in some way.

With this change it will wait for a bit (at least 10 seconds), before
shutting down, so when reloading there is plenty of time to load the
script again without instances shutting down.