### PR TITLE
Bugfix: Let AudioPlayer thread shut fully down

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@
  - WinFormUI: Console lines are now timestamped
  - WebWidgets: HTTP Server now listens on all IPs
  - Core: When Lua scripts stop using a instance, then wait for a bit before shutting it down.
+ - Audio: Bugfix: Audio thread not shutting properly down
 
 ## [0.10.0](https://github.com/dennis/slipstream/releases/tag/v0.10.0) (2021-10-07)
 [Full Changelog](https://github.com/dennis/slipstream/compare/v0.9.0...v0.10.0)

--- a/Components/Audio/Lua/AudioInstanceThread.AudioPlayerImpl.cs
+++ b/Components/Audio/Lua/AudioInstanceThread.AudioPlayerImpl.cs
@@ -137,8 +137,6 @@ namespace Slipstream.Components.Audio.Lua
                         } while (@event != null);
                     }
                 }
-
-                AudioPlayerThread.Join();
             }
 
             private void OnAudioCommandPlay(AudioCommandPlay @event)

--- a/Components/WinFormUI/Forms/MainWindow.cs
+++ b/Components/WinFormUI/Forms/MainWindow.cs
@@ -253,7 +253,6 @@ namespace Slipstream.Components.WinFormUI.Forms
                 EndpointsToolStripMenuItem.Enabled = true;
 
                 var openItem = new ToolStripMenuItem("Open in browser");
-            http://*:1919/instances/focused-mode
                 openItem.Click += (_, e) => { Process.Start(new ProcessStartInfo(endpoint) { UseShellExecute = true }); };
                 var copyItem = new ToolStripMenuItem("Copy to clipboard");
                 copyItem.Click += (_, e) => CopyToClipBoard(endpoint);


### PR DESCRIPTION
Inside the thread, we were blocking until it would would finish. Which
never happens, because the thread were blocking until it would would
finish.  Which never happens ..