### PR TITLE
bugfix: Broekn generate_json() lua function

### DIFF
--- a/Components/Lua/Lua/LuaInstanceThread.cs
+++ b/Components/Lua/Lua/LuaInstanceThread.cs
@@ -335,7 +335,7 @@ end
         }
 
         [System.Diagnostics.CodeAnalysis.SuppressMessage("Style", "IDE1006:Naming Styles", Justification = "This is expose in Lua, so we want to keep that naming style")]
-        public static string generate_json(LuaTable luaTable)
+        public string generate_json(LuaTable luaTable)
         {
             return JsonConvert.SerializeObject(Parameters.From(luaTable));
         }


### PR DESCRIPTION
Would error with:
errored while invoking handle(): Can't pass instance to static method generate_json

Did a refactoring that suggested adding 'static' to the method signature